### PR TITLE
Make a failed update say what went wrong, and make the APK provider replaceable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
           find config packaging/flatpak -type f -name '*.json' -print0 \
             | xargs -0 -n1 python3 -m json.tool >/dev/null
 
+      - name: Run script unit tests
+        shell: bash
+        run: |
+          python3 -m pip install --disable-pip-version-check requests
+          python3 -m unittest discover -s tests -p '*_test.py' -v
+
       - name: Verify build and packaging contracts
         shell: bash
         run: |

--- a/.github/workflows/payload-metadata-watch.yml
+++ b/.github/workflows/payload-metadata-watch.yml
@@ -1,0 +1,70 @@
+name: Payload metadata watch
+
+on:
+  schedule:
+    # Roblox retires client versions on its own cadence, so check daily rather
+    # than waiting for a user to report a failed first launch.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: payload-metadata-watch
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: Pinned payload metadata
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install provider dependencies
+        run: python3 -m pip install --disable-pip-version-check requests
+
+      - name: Inspect pinned payload metadata
+        id: drift
+        shell: bash
+        run: |
+          set +e
+          report="$(python3 scripts/check_payload_source_drift.py --check-latest 2>&1)"
+          status=$?
+          set -e
+          printf '%s\n' "${report}"
+          {
+            echo "status=${status}"
+            echo 'report<<REPORT_EOF'
+            printf '%s\n' "${report}"
+            echo 'REPORT_EOF'
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Open or refresh the tracking issue
+        if: steps.drift.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT: ${{ steps.drift.outputs.report }}
+          TITLE: Pinned Roblox payload metadata has drifted
+        shell: bash
+        run: |
+          body="$(printf '%s\n\n%s\n' \
+            "${REPORT}" \
+            "Reported by \`scripts/check_payload_source_drift.py\` in [this run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}).")"
+          existing="$(gh issue list --state open --search "in:title \"${TITLE}\"" \
+            --json number,title --jq \
+            ".[] | select(.title == \"${TITLE}\") | .number" | head -n1)"
+          if [[ -n "${existing}" ]]; then
+            # Refresh in place: a daily comment on an unchanged condition is
+            # noise, and the body always shows the current state.
+            gh issue edit "${existing}" --body "${body}"
+          else
+            gh issue create --title "${TITLE}" --body "${body}"
+          fi
+
+      - name: Fail the run when the provider cannot be inspected
+        if: steps.drift.outputs.status == '2'
+        run: exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ pkg_check_modules(WEBKITGTK6 REQUIRED IMPORTED_TARGET webkitgtk-6.0)
 add_library(mocktail_update STATIC
   src/update/android_manifest.cc
   src/update/apk_bundle.cc
+  src/update/apk_provider.cc
   src/update/apk_signature.cc
   src/update/apkpure_provider.cc
   src/update/candidate_approval.cc

--- a/config/mocktail.example.yaml
+++ b/config/mocktail.example.yaml
@@ -118,7 +118,9 @@ updates:
   # backend, and promote only on success. An existing current payload is
   # preserved when probation fails.
   automatic: true
-  # String (default: apk-pure): direct x86_64 APK provider.
+  # String (default: apk-pure): direct x86_64 APK provider selection. Both
+  # accepted values resolve the provider chain, which currently starts with
+  # APKPure. Supported values: auto, apk-pure.
   source: apk-pure
   # Reserved for desktop update integrations. `mocktail_updater` itself never
   # launches another process after changing the active payload.

--- a/include/runtime/payload_update_preflight.h
+++ b/include/runtime/payload_update_preflight.h
@@ -12,6 +12,9 @@ namespace runtime {
 struct PayloadUpdatePreflightResult {
   bool attempted = false;
   std::string error;
+  // Last failure the updater reported on its own stderr. Empty when the
+  // updater never ran or never explained itself.
+  std::string details;
 
   explicit operator bool() const { return error.empty(); }
 };

--- a/include/update/apk_provider.h
+++ b/include/update/apk_provider.h
@@ -1,0 +1,69 @@
+#ifndef MOCKTAIL_UPDATE_APK_PROVIDER_H_
+#define MOCKTAIL_UPDATE_APK_PROVIDER_H_
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace mocktail::update {
+
+struct ProviderVersion {
+  std::string version_name;
+  std::uint64_t version_code = 0;
+  std::string error;
+
+  explicit operator bool() const { return error.empty(); }
+};
+
+struct ProviderDownloadResult {
+  std::vector<std::filesystem::path> archives;
+  // Provider that produced the archives, so a stored payload can be traced
+  // back to where it came from.
+  std::string source;
+  std::string error;
+
+  explicit operator bool() const { return error.empty(); }
+};
+
+// A source of Roblox APK archives. Providers are interchangeable: whichever
+// one answers first wins, and every archive still passes the same signature,
+// Build-ID, and ABI verification afterwards.
+class ApkProvider {
+ public:
+  virtual ~ApkProvider() = default;
+
+  // Short stable identifier, recorded in payload receipts and error messages.
+  virtual std::string_view name() const = 0;
+
+  // Latest published version. A provider that only serves pinned versions
+  // reports an error here and stays usable through DownloadExact.
+  virtual ProviderVersion CheckLatest() const = 0;
+
+  virtual ProviderDownloadResult DownloadExact(
+      std::string_view version, const std::filesystem::path& output_directory,
+      int progress_fd) const = 0;
+};
+
+// Tries every provider in order. One unreachable provider is the most common
+// first-run failure, and on its own it must not fail the whole update.
+class ProviderChain final : public ApkProvider {
+ public:
+  void Add(std::unique_ptr<ApkProvider> provider);
+  bool empty() const { return providers_.empty(); }
+
+  std::string_view name() const override { return "provider-chain"; }
+  ProviderVersion CheckLatest() const override;
+  ProviderDownloadResult DownloadExact(
+      std::string_view version, const std::filesystem::path& output_directory,
+      int progress_fd) const override;
+
+ private:
+  std::vector<std::unique_ptr<ApkProvider>> providers_;
+};
+
+}  // namespace mocktail::update
+
+#endif  // MOCKTAIL_UPDATE_APK_PROVIDER_H_

--- a/include/update/apkpure_provider.h
+++ b/include/update/apkpure_provider.h
@@ -1,28 +1,14 @@
 #ifndef MOCKTAIL_UPDATE_APKPURE_PROVIDER_H_
 #define MOCKTAIL_UPDATE_APKPURE_PROVIDER_H_
 
-#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "update/apk_provider.h"
+
 namespace mocktail::update {
-
-struct ProviderVersion {
-  std::string version_name;
-  std::uint64_t version_code = 0;
-  std::string error;
-
-  explicit operator bool() const { return error.empty(); }
-};
-
-struct ProviderDownloadResult {
-  std::vector<std::filesystem::path> archives;
-  std::string error;
-
-  explicit operator bool() const { return error.empty(); }
-};
 
 ProviderVersion ParseApkPureLatestMetadata(std::string_view metadata);
 
@@ -30,13 +16,15 @@ std::vector<std::string> ParseApkPureExactDownloadUrls(
     std::string_view metadata, std::string_view version,
     std::string* error = nullptr);
 
-class ApkPureProvider final {
+class ApkPureProvider final : public ApkProvider {
  public:
-  ProviderVersion CheckLatest() const;
+  std::string_view name() const override { return "apk-pure"; }
+
+  ProviderVersion CheckLatest() const override;
 
   ProviderDownloadResult DownloadExact(
       std::string_view version, const std::filesystem::path& output_directory,
-      int progress_fd = -1) const;
+      int progress_fd = -1) const override;
 };
 
 }  // namespace mocktail::update

--- a/scripts/check_payload_source_drift.py
+++ b/scripts/check_payload_source_drift.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# Copyright 2026 Mocktail Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Report when the pinned Roblox payload metadata has fallen behind.
+
+Two kinds of drift make a first launch fail, and neither one shows up until a
+user hits it:
+
+* the compatibility catalog no longer lists the Roblox version the provider
+  publishes, so every new install lands on a version Roblox has since retired;
+* the preferred supported profile has no pinned bootstrap source, so the
+  pinned bootstrap path cannot produce the version the updater falls back to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+PACKAGE = "com.roblox.client"
+ARCHITECTURE = "x86_64"
+
+
+class DriftError(RuntimeError):
+    """Raised when the pinned metadata cannot be inspected at all."""
+
+
+def _load(path: Path) -> dict:
+    try:
+        encoded = path.read_bytes()
+    except OSError as error:
+        raise DriftError(f"cannot read {path}") from error
+    if len(encoded) > MAX_MANIFEST_BYTES:
+        raise DriftError(f"{path} exceeds its size limit")
+    try:
+        document = json.loads(encoded.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise DriftError(f"cannot parse {path}") from error
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise DriftError(f"{path} has an unsupported schema")
+    return document
+
+
+def supported_profiles(catalog: dict) -> list[dict]:
+    profiles = catalog.get("profiles")
+    if not isinstance(profiles, list):
+        raise DriftError("compatibility catalog has no profiles")
+    return [
+        profile
+        for profile in profiles
+        if isinstance(profile, dict)
+        and profile.get("status") == "supported"
+        and profile.get("default_allowed") is True
+        and isinstance(profile.get("version_name"), str)
+        and isinstance(profile.get("version_code"), int)
+    ]
+
+
+def preferred_profile(catalog: dict) -> dict:
+    """The profile the updater falls back to, matching the C++ coordinator."""
+    profiles = supported_profiles(catalog)
+    if not profiles:
+        raise DriftError("compatibility catalog has no supported profile")
+    return max(profiles, key=lambda profile: profile["version_code"])
+
+
+def pinned_versions(sources: dict) -> set[str]:
+    entries = sources.get("sources")
+    if not isinstance(entries, list):
+        raise DriftError("bootstrap source manifest has no sources")
+    return {
+        entry["version_name"]
+        for entry in entries
+        if isinstance(entry, dict)
+        and entry.get("package") == PACKAGE
+        and entry.get("abi") == ARCHITECTURE
+        and isinstance(entry.get("version_name"), str)
+    }
+
+
+def latest_published_version(provider: Path) -> tuple[str, int]:
+    completed = subprocess.run(
+        [sys.executable, str(provider), "--check", "--package", PACKAGE,
+         "--arch", ARCHITECTURE],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise DriftError(
+            "provider metadata is unavailable: "
+            + (completed.stderr.strip() or "no diagnostic")
+        )
+    try:
+        reported = json.loads(completed.stdout)
+        return str(reported["latest_version_name"]), int(
+            reported["latest_version_code"]
+        )
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        raise DriftError("provider metadata is not understood") from error
+
+
+def findings(catalog: dict, sources: dict, latest: tuple[str, int] | None
+             ) -> list[str]:
+    reported: list[str] = []
+    preferred = preferred_profile(catalog)
+    pinned = pinned_versions(sources)
+    if preferred["version_name"] not in pinned:
+        reported.append(
+            f"The preferred supported profile {preferred['version_name']} "
+            f"({preferred['version_code']}) has no pinned bootstrap source. "
+            "The pinned bootstrap path cannot produce the version the updater "
+            "falls back to."
+        )
+    if latest is not None:
+        latest_name, latest_code = latest
+        if latest_code > preferred["version_code"]:
+            reported.append(
+                f"Roblox {latest_name} ({latest_code}) is published, but the "
+                f"newest supported profile is {preferred['version_name']} "
+                f"({preferred['version_code']}). New installs land on a "
+                "version Roblox may already have retired."
+            )
+    return reported
+
+
+def main(argv: list[str] | None = None) -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--catalog", type=Path,
+        default=root / "config/roblox_compatibility.json")
+    parser.add_argument(
+        "--sources", type=Path,
+        default=root / "config/roblox_bootstrap_sources.json")
+    parser.add_argument(
+        "--provider", type=Path,
+        default=root / "scripts/apk_providers/direct_apkpure.py")
+    parser.add_argument(
+        "--check-latest", action="store_true",
+        help="also ask the provider which version is published")
+    arguments = parser.parse_args(argv)
+
+    try:
+        catalog = _load(arguments.catalog)
+        sources = _load(arguments.sources)
+        latest = (
+            latest_published_version(arguments.provider)
+            if arguments.check_latest
+            else None
+        )
+        reported = findings(catalog, sources, latest)
+    except DriftError as error:
+        print(f"payload source drift: {error}", file=sys.stderr)
+        return 2
+
+    if not reported:
+        print("Pinned Roblox payload metadata is current.")
+        return 0
+    for finding in reported:
+        print(f"- {finding}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main.cc
+++ b/src/main.cc
@@ -145,7 +145,11 @@ int main(int argc, char* argv[]) {
     const mocktail::runtime::PayloadUpdatePreflightResult force_latest =
         mocktail::runtime::RunPayloadUpdatePreflight(environment, paths, true);
     if (!force_latest) {
-      std::cerr << "[FATAL] " << force_latest.error << '\n';
+      std::cerr << "[FATAL] " << force_latest.error;
+      if (!force_latest.details.empty()) {
+        std::cerr << ": " << force_latest.details;
+      }
+      std::cerr << '\n';
       return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;
@@ -430,7 +434,18 @@ int main(int argc, char* argv[]) {
     const mocktail::runtime::PayloadUpdatePreflightResult update_preflight =
         mocktail::runtime::RunPayloadUpdatePreflight(environment, paths);
     if (!update_preflight) {
-      std::cerr << "[FATAL] " << update_preflight.error << '\n';
+      std::cerr << "[FATAL] " << update_preflight.error;
+      if (!update_preflight.details.empty()) {
+        // Without this the dialog only ever said "could not update or verify",
+        // which is indistinguishable between a provider outage, a rejected
+        // signature, and a full disk.
+        std::cerr << ": " << update_preflight.details;
+        failure_dialog.SetMessage(
+            "Mocktail could not update or verify the Roblox installation.\n\n" +
+            update_preflight.details + "\n\nSession log: " +
+            (paths.logs_root() / "sessions").string());
+      }
+      std::cerr << '\n';
       return EXIT_FAILURE;
     }
     failure_dialog.SetMessage(

--- a/src/runtime/payload_update_preflight.cc
+++ b/src/runtime/payload_update_preflight.cc
@@ -1,11 +1,14 @@
 #include "runtime/payload_update_preflight.h"
 
+#include <fcntl.h>
 #include <spawn.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <array>
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <optional>
@@ -219,6 +222,120 @@ bool IsOverriddenEnvironmentEntry(
   return false;
 }
 
+// The updater runs as a separate process, so the reason it failed ("api.
+// pureapk.com request returned status 503") only ever reached the session log.
+// Relay its stderr verbatim and keep the last failure it reported, so the
+// launcher can tell the user what actually went wrong.
+class UpdaterStderrRelay final {
+ public:
+  UpdaterStderrRelay() {
+    if (pipe2(descriptors_, O_CLOEXEC) != 0) {
+      descriptors_[0] = -1;
+      descriptors_[1] = -1;
+    }
+  }
+
+  ~UpdaterStderrRelay() {
+    CloseDescriptor(&descriptors_[0]);
+    CloseWrite();
+  }
+
+  UpdaterStderrRelay(const UpdaterStderrRelay&) = delete;
+  UpdaterStderrRelay& operator=(const UpdaterStderrRelay&) = delete;
+
+  bool active() const { return descriptors_[0] >= 0; }
+  int write_descriptor() const { return descriptors_[1]; }
+  void CloseWrite() { CloseDescriptor(&descriptors_[1]); }
+  const std::string& failure() const { return failure_; }
+
+  // Must run before waitpid: a child that fills the pipe blocks until it is
+  // drained, and waiting first would deadlock the launcher.
+  void Drain() {
+    if (!active()) {
+      return;
+    }
+    std::string pending;
+    std::array<char, 4096> buffer{};
+    while (true) {
+      const ssize_t received =
+          read(descriptors_[0], buffer.data(), buffer.size());
+      if (received < 0 && errno == EINTR) {
+        continue;
+      }
+      if (received <= 0) {
+        break;
+      }
+      const auto bytes = static_cast<std::size_t>(received);
+      WriteAll(buffer.data(), bytes);
+      pending.append(buffer.data(), bytes);
+      for (std::size_t end = pending.find('\n'); end != std::string::npos;
+           end = pending.find('\n')) {
+        RecordLine(std::string_view(pending).substr(0, end));
+        pending.erase(0, end + 1);
+      }
+    }
+    RecordLine(pending);
+    CloseDescriptor(&descriptors_[0]);
+  }
+
+ private:
+  // An Adwaita alert dialog stays readable well below the packet limit.
+  static constexpr std::size_t kMaximumFailureBytes = 400;
+
+  static void CloseDescriptor(int* descriptor) {
+    if (*descriptor >= 0) {
+      close(*descriptor);
+      *descriptor = -1;
+    }
+  }
+
+  static void WriteAll(const char* data, std::size_t bytes) {
+    std::size_t offset = 0;
+    while (offset < bytes) {
+      const ssize_t written =
+          write(STDERR_FILENO, data + offset, bytes - offset);
+      if (written < 0 && errno == EINTR) {
+        continue;
+      }
+      if (written <= 0) {
+        return;
+      }
+      offset += static_cast<std::size_t>(written);
+    }
+  }
+
+  // A message cut mid-codepoint fails UTF-8 validation in the dialog helper
+  // and would be replaced by the generic text.
+  static std::string_view TrimToCharacterBoundary(std::string_view text) {
+    if (text.size() <= kMaximumFailureBytes) {
+      return text;
+    }
+    std::size_t size = kMaximumFailureBytes;
+    while (size > 0 &&
+           (static_cast<unsigned char>(text[size]) & 0xC0U) == 0x80U) {
+      --size;
+    }
+    return text.substr(0, size);
+  }
+
+  void RecordLine(std::string_view line) {
+    constexpr std::string_view kPrefix = "[native-updater] ";
+    constexpr std::string_view kWarningPrefix = "warning: ";
+    if (line.size() <= kPrefix.size() ||
+        line.substr(0, kPrefix.size()) != kPrefix) {
+      return;
+    }
+    const std::string_view detail = line.substr(kPrefix.size());
+    if (detail.substr(0, kWarningPrefix.size()) == kWarningPrefix) {
+      return;
+    }
+    failure_.assign(TrimToCharacterBoundary(detail));
+  }
+
+  int descriptors_[2] = {-1, -1};
+  std::string failure_;
+};
+
 std::vector<std::string> ChildEnvironment(const RuntimePaths& paths,
                                           bool progress_enabled) {
   const std::vector<std::pair<std::string_view, std::filesystem::path>>
@@ -283,16 +400,21 @@ PayloadUpdatePreflightResult RunPayloadUpdatePreflight(
     child_environment_pointers.push_back(entry.data());
   }
   child_environment_pointers.push_back(nullptr);
+  UpdaterStderrRelay stderr_relay;
   posix_spawn_file_actions_t actions;
   bool actions_initialized = false;
   int action_status = 0;
-  if (progress.active()) {
+  if (progress.active() || stderr_relay.active()) {
     action_status = posix_spawn_file_actions_init(&actions);
     actions_initialized = action_status == 0;
-    if (action_status == 0) {
-      action_status = posix_spawn_file_actions_adddup2(
-          &actions, progress.socket(), kUpdaterProgressDescriptor);
-    }
+  }
+  if (action_status == 0 && progress.active()) {
+    action_status = posix_spawn_file_actions_adddup2(
+        &actions, progress.socket(), kUpdaterProgressDescriptor);
+  }
+  if (action_status == 0 && stderr_relay.active()) {
+    action_status = posix_spawn_file_actions_adddup2(
+        &actions, stderr_relay.write_descriptor(), STDERR_FILENO);
   }
   if (action_status != 0) {
     if (actions_initialized) {
@@ -315,6 +437,10 @@ PayloadUpdatePreflightResult RunPayloadUpdatePreflight(
     return result;
   }
 
+  // The child owns the write end now; the relay must observe end-of-file.
+  stderr_relay.CloseWrite();
+  stderr_relay.Drain();
+
   int child_status = 0;
   while (waitpid(child, &child_status, 0) < 0) {
     if (errno == EINTR) {
@@ -327,6 +453,7 @@ PayloadUpdatePreflightResult RunPayloadUpdatePreflight(
   if (!WIFEXITED(child_status) || WEXITSTATUS(child_status) != 0) {
     result.error = force_run_latest ? "forced latest Roblox run failed"
                                      : "Roblox update preflight failed";
+    result.details = stderr_relay.failure();
   }
   return result;
 }

--- a/src/runtime/runtime_config_bootstrap.cc
+++ b/src/runtime/runtime_config_bootstrap.cc
@@ -136,7 +136,9 @@ updates:
   # backend, and promote only on success. An existing current payload is
   # preserved when probation fails.
   automatic: true
-  # String (default: apk-pure): direct x86_64 APK provider.
+  # String (default: apk-pure): direct x86_64 APK provider selection. Both
+  # accepted values resolve the provider chain, which currently starts with
+  # APKPure. Supported values: auto, apk-pure.
   source: apk-pure
   # Reserved for desktop update integrations. `mocktail_updater` itself never
   # launches another process after changing the active payload.

--- a/src/update/apk_provider.cc
+++ b/src/update/apk_provider.cc
@@ -1,0 +1,61 @@
+#include "update/apk_provider.h"
+
+#include <string>
+#include <utility>
+
+namespace mocktail::update {
+namespace {
+
+void AppendFailure(std::string* aggregate, std::string_view provider,
+                   std::string_view failure) {
+  if (!aggregate->empty()) aggregate->append("; ");
+  aggregate->append(provider);
+  aggregate->append(": ");
+  aggregate->append(failure);
+}
+
+}  // namespace
+
+void ProviderChain::Add(std::unique_ptr<ApkProvider> provider) {
+  if (provider != nullptr) providers_.push_back(std::move(provider));
+}
+
+ProviderVersion ProviderChain::CheckLatest() const {
+  ProviderVersion result;
+  if (providers_.empty()) {
+    result.error = "no APK provider is configured";
+    return result;
+  }
+  std::string failures;
+  for (const std::unique_ptr<ApkProvider>& provider : providers_) {
+    const ProviderVersion version = provider->CheckLatest();
+    if (version) return version;
+    AppendFailure(&failures, provider->name(), version.error);
+  }
+  result.error = std::move(failures);
+  return result;
+}
+
+ProviderDownloadResult ProviderChain::DownloadExact(
+    std::string_view version, const std::filesystem::path& output_directory,
+    int progress_fd) const {
+  ProviderDownloadResult result;
+  if (providers_.empty()) {
+    result.error = "no APK provider is configured";
+    return result;
+  }
+  std::string failures;
+  for (const std::unique_ptr<ApkProvider>& provider : providers_) {
+    // Each provider gets its own directory: providers refuse to write into a
+    // directory another one already populated, and a failed attempt must not
+    // poison the next.
+    ProviderDownloadResult downloaded = provider->DownloadExact(
+        version, output_directory / provider->name(), progress_fd);
+    if (downloaded) return downloaded;
+    AppendFailure(&failures, provider->name(), downloaded.error);
+  }
+  result.error = std::move(failures);
+  return result;
+}
+
+}  // namespace mocktail::update

--- a/src/update/apkpure_provider.cc
+++ b/src/update/apkpure_provider.cc
@@ -208,6 +208,7 @@ ProviderDownloadResult ApkPureProvider::DownloadExact(
     std::string_view version, const std::filesystem::path& output_directory,
     int progress_fd) const {
   ProviderDownloadResult result;
+  result.source = std::string(name());
   if (version.empty() || version.size() > 128 ||
       !std::all_of(version.begin(), version.end(), [](unsigned char character) {
         return VersionCharacter(character);

--- a/src/update/http_download.cc
+++ b/src/update/http_download.cc
@@ -196,6 +196,30 @@ std::string CurlFailure(CURLcode status,
                            : std::string(curl_easy_strerror(status));
 }
 
+std::string UrlHost(std::string_view url) {
+  std::unique_ptr<CURLU, CurlUrlDeleter> parsed(curl_url());
+  char* raw_host = nullptr;
+  if (!parsed ||
+      curl_url_set(parsed.get(), CURLUPART_URL, std::string(url).c_str(), 0) !=
+          CURLUE_OK ||
+      curl_url_get(parsed.get(), CURLUPART_HOST, &raw_host, 0) != CURLUE_OK ||
+      raw_host == nullptr) {
+    return {};
+  }
+  std::unique_ptr<char, CurlStringDeleter> host(raw_host);
+  return Lower(host.get());
+}
+
+// Provider outages are the most common first-run failure, so the host that
+// rejected the transfer belongs in the message the user actually reads.
+std::string StatusFailure(std::string_view action, std::string_view url,
+                          long status_code) {
+  const std::string host = UrlHost(url);
+  return (host.empty() ? std::string("HTTPS ") + std::string(action)
+                       : host + " " + std::string(action)) +
+         " returned status " + std::to_string(status_code);
+}
+
 }  // namespace
 
 bool IsTrustedHttpsUrl(std::string_view url,
@@ -293,8 +317,7 @@ HttpBytesResult DownloadBytes(const HttpTransferRequest& request) {
       continue;
     }
     if (result.status_code < 200 || result.status_code >= 300) {
-      result.error =
-          "HTTPS request returned status " + std::to_string(result.status_code);
+      result.error = StatusFailure("request", current, result.status_code);
       return result;
     }
     result.final_url = current;
@@ -391,9 +414,9 @@ HttpDownloadResult DownloadFile(const HttpTransferRequest& request,
     }
     if (http_status < 200 || http_status >= 300 || writer.written == 0) {
       std::filesystem::remove(temporary, filesystem_error);
-      result.error = writer.written == 0 ? "HTTPS download is empty"
-                                         : "HTTPS download returned status " +
-                                               std::to_string(http_status);
+      result.error = writer.written == 0
+                         ? "HTTPS download is empty"
+                         : StatusFailure("download", current, http_status);
       return result;
     }
     std::filesystem::rename(temporary, destination, filesystem_error);

--- a/src/update/update_config.cc
+++ b/src/update/update_config.cc
@@ -167,8 +167,12 @@ UpdateConfigResult LoadUpdateConfig(const std::filesystem::path& path) {
       }
     } else if (key == "source") {
       result.config.source = Scalar(value);
-      if (result.config.source != "apk-pure") {
-        result.error = "updates.source must be apk-pure in the native updater";
+      // `apk-pure` predates the fallback chain and still selects it, so an
+      // existing configuration file keeps working unchanged.
+      if (result.config.source != "apk-pure" &&
+          result.config.source != "auto") {
+        result.error =
+            "updates.source must be auto or apk-pure in the native updater";
         break;
       }
     } else {

--- a/src/update/update_coordinator.cc
+++ b/src/update/update_coordinator.cc
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstring>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -16,6 +17,7 @@
 
 #include "compat/elf_build_id.h"
 #include "update/apk_bundle.h"
+#include "update/apk_provider.h"
 #include "update/apkpure_provider.h"
 #include "update/compatibility_catalog.h"
 #include "update/host_abi_deriver.h"
@@ -189,7 +191,15 @@ void RecordRejection(const UpdatePaths& paths, const Candidate& candidate,
   close(descriptor);
 }
 
-Candidate DownloadCandidate(ApkPureProvider* provider, PayloadStore* store,
+// Built once per run. Providers are consulted in order, so adding a second
+// source is a one-line change here rather than a rewrite of the coordinator.
+ProviderChain BuildProviderChain() {
+  ProviderChain chain;
+  chain.Add(std::make_unique<ApkPureProvider>());
+  return chain;
+}
+
+Candidate DownloadCandidate(const ApkProvider* provider, PayloadStore* store,
                             const ExpectedPayloadIdentity& identity,
                             bool exact_supported, const UpdatePaths& paths,
                             const std::filesystem::path& workspace,
@@ -207,7 +217,7 @@ Candidate DownloadCandidate(ApkPureProvider* provider, PayloadStore* store,
   Progress(progress_fd, "Verifying Roblox...");
   const PreparedPayload prepared = PreparePayloadFromArchives(
       downloaded.archives, identity, paths.signing_trust_manifest,
-      workspace / "prepare", "apk-pure-native");
+      workspace / "prepare", downloaded.source + "-native");
   if (!prepared) {
     result.error = prepared.error;
     return result;
@@ -230,7 +240,7 @@ struct ReferenceProfile {
 ReferenceProfile ResolveReference(const UpdatePaths& paths,
                                   const PayloadStoreResult& installed,
                                   const SupportedPayloadProfile& preferred,
-                                  ApkPureProvider* provider,
+                                  const ApkProvider* provider,
                                   PayloadStore* store,
                                   const std::filesystem::path& workspace,
                                   int progress_fd) {
@@ -290,7 +300,7 @@ UpdateResult RunUnsafeLatest(
     return result;
   }
 
-  ApkPureProvider provider;
+  const ProviderChain provider = BuildProviderChain();
   Progress(request.progress_fd, "Checking latest Roblox...");
   const ProviderVersion latest = provider.CheckLatest();
   if (!latest) {
@@ -457,8 +467,9 @@ UpdateResult RunUpdate(const UpdatePaths& paths, const UpdateRequest& request) {
     result.error = configured.error;
     return result;
   }
-  if (configured.config.source != "apk-pure") {
-    result.error = "native updater supports only the direct APKPure provider";
+  if (configured.config.source != "apk-pure" &&
+      configured.config.source != "auto") {
+    result.error = "native updater supports only the direct APK providers";
     return result;
   }
   const CompatibilityCatalogResult catalog =
@@ -503,7 +514,7 @@ UpdateResult RunUpdate(const UpdatePaths& paths, const UpdateRequest& request) {
         "no runnable payload is installed and automatic updates are disabled";
     return result;
   }
-  ApkPureProvider provider;
+  const ProviderChain provider = BuildProviderChain();
   std::optional<ProviderVersion> latest_version;
   if (request.check_latest) {
     Progress(request.progress_fd, "Checking Roblox...");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,12 @@ target_link_libraries(native_update_test PRIVATE
   GTest::gtest_main
 )
 
+add_executable(apk_provider_test apk_provider_test.cc)
+target_link_libraries(apk_provider_test PRIVATE
+  Mocktail::Update
+  GTest::gtest_main
+)
+
 add_executable(support_bundle_runtime_test support_bundle_runtime_test.cc)
 target_link_libraries(support_bundle_runtime_test PRIVATE
   Mocktail::Runtime
@@ -807,6 +813,7 @@ gtest_discover_tests(jnivm_test)
 gtest_discover_tests(runtime_config_test)
 gtest_discover_tests(runtime_config_file_test)
 gtest_discover_tests(payload_update_preflight_test)
+gtest_discover_tests(apk_provider_test)
 gtest_discover_tests(native_update_test)
 gtest_discover_tests(support_bundle_runtime_test)
 gtest_discover_tests(session_log_test)

--- a/tests/apk_provider_test.cc
+++ b/tests/apk_provider_test.cc
@@ -1,0 +1,94 @@
+#include "update/apk_provider.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace mocktail::update {
+namespace {
+
+class StubProvider final : public ApkProvider {
+ public:
+  StubProvider(std::string name, std::string failure)
+      : name_(std::move(name)), failure_(std::move(failure)) {}
+
+  std::string_view name() const override { return name_; }
+
+  ProviderVersion CheckLatest() const override {
+    ProviderVersion version;
+    if (failure_.empty()) {
+      version.version_name = "2.727.1199";
+      version.version_code = 2628;
+    } else {
+      version.error = failure_;
+    }
+    return version;
+  }
+
+  ProviderDownloadResult DownloadExact(std::string_view,
+                                       const std::filesystem::path& directory,
+                                       int) const override {
+    ProviderDownloadResult result;
+    result.source = name_;
+    if (failure_.empty()) {
+      result.archives.push_back(directory / "candidate.apk");
+    } else {
+      result.error = failure_;
+    }
+    return result;
+  }
+
+ private:
+  std::string name_;
+  std::string failure_;
+};
+
+TEST(ProviderChainTest, FallsBackToTheNextProvider) {
+  ProviderChain chain;
+  chain.Add(std::make_unique<StubProvider>("apk-pure",
+                                           "api.pureapk.com request "
+                                           "returned status 503"));
+  chain.Add(std::make_unique<StubProvider>("pinned-mirror", ""));
+  const ProviderDownloadResult downloaded =
+      chain.DownloadExact("2.725.1142", "/tmp/mocktail-chain", -1);
+  ASSERT_TRUE(downloaded) << downloaded.error;
+  EXPECT_EQ(downloaded.source, "pinned-mirror");
+  ASSERT_EQ(downloaded.archives.size(), 1U);
+  // Each provider downloads into its own directory so a failed attempt cannot
+  // block the next one.
+  EXPECT_EQ(downloaded.archives.front(),
+            std::filesystem::path("/tmp/mocktail-chain/pinned-mirror/candidate.apk"));
+}
+
+TEST(ProviderChainTest, ReportsEveryProviderWhenAllFail) {
+  ProviderChain chain;
+  chain.Add(std::make_unique<StubProvider>("apk-pure", "returned status 503"));
+  chain.Add(std::make_unique<StubProvider>("pinned-mirror", "no pinned source"));
+  const ProviderDownloadResult downloaded =
+      chain.DownloadExact("2.734.917", "/tmp/mocktail-chain", -1);
+  EXPECT_FALSE(downloaded);
+  EXPECT_EQ(downloaded.error,
+            "apk-pure: returned status 503; pinned-mirror: no pinned source");
+}
+
+TEST(ProviderChainTest, PrefersTheFirstProviderThatAnswers) {
+  ProviderChain chain;
+  chain.Add(std::make_unique<StubProvider>("apk-pure", ""));
+  chain.Add(std::make_unique<StubProvider>("pinned-mirror", ""));
+  const ProviderVersion latest = chain.CheckLatest();
+  ASSERT_TRUE(latest) << latest.error;
+  EXPECT_EQ(latest.version_name, "2.727.1199");
+}
+
+TEST(ProviderChainTest, ReportsAnEmptyChain) {
+  const ProviderChain chain;
+  EXPECT_TRUE(chain.empty());
+  EXPECT_EQ(chain.CheckLatest().error, "no APK provider is configured");
+}
+
+}  // namespace
+}  // namespace mocktail::update

--- a/tests/check_payload_source_drift_test.py
+++ b/tests/check_payload_source_drift_test.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright 2026 Mocktail Project Authors
+# Licensed under the Apache License, Version 2.0.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts/check_payload_source_drift.py"
+SPEC = importlib.util.spec_from_file_location("check_payload_source_drift",
+                                              SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+drift = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(drift)
+
+
+def catalog(*profiles: tuple[str, int, bool]) -> dict:
+    return {
+        "schema_version": 1,
+        "profiles": [
+            {
+                "version_name": name,
+                "version_code": code,
+                "status": "supported" if allowed else "legacy-researched",
+                "default_allowed": allowed,
+            }
+            for name, code, allowed in profiles
+        ],
+    }
+
+
+def sources(*versions: str) -> dict:
+    return {
+        "schema_version": 1,
+        "sources": [
+            {
+                "package": "com.roblox.client",
+                "version_name": version,
+                "abi": "x86_64",
+                "provider": "uptodown",
+            }
+            for version in versions
+        ],
+    }
+
+
+class PreferredProfileTest(unittest.TestCase):
+    def test_picks_the_highest_allowed_version_code(self) -> None:
+        preferred = drift.preferred_profile(
+            catalog(("2.725.1142", 2546, True), ("2.727.1199", 2628, True))
+        )
+        self.assertEqual(preferred["version_name"], "2.727.1199")
+
+    def test_ignores_profiles_that_are_not_default_allowed(self) -> None:
+        preferred = drift.preferred_profile(
+            catalog(("2.725.1142", 2546, True), ("2.740.1", 2900, False))
+        )
+        self.assertEqual(preferred["version_name"], "2.725.1142")
+
+    def test_rejects_a_catalog_without_a_supported_profile(self) -> None:
+        with self.assertRaises(drift.DriftError):
+            drift.preferred_profile(catalog(("2.721.1108", 2350, False)))
+
+
+class FindingsTest(unittest.TestCase):
+    def test_reports_nothing_when_metadata_is_current(self) -> None:
+        reported = drift.findings(
+            catalog(("2.727.1199", 2628, True)),
+            sources("2.727.1199"),
+            ("2.727.1199", 2628),
+        )
+        self.assertEqual(reported, [])
+
+    def test_reports_an_unpinned_fallback(self) -> None:
+        reported = drift.findings(
+            catalog(("2.725.1142", 2546, True), ("2.727.1199", 2628, True)),
+            sources("2.725.1142"),
+            None,
+        )
+        self.assertEqual(len(reported), 1)
+        self.assertIn("no pinned bootstrap source", reported[0])
+        self.assertIn("2.727.1199", reported[0])
+
+    def test_reports_a_catalog_behind_the_published_version(self) -> None:
+        reported = drift.findings(
+            catalog(("2.727.1199", 2628, True)),
+            sources("2.727.1199"),
+            ("2.734.917", 2908),
+        )
+        self.assertEqual(len(reported), 1)
+        self.assertIn("2.734.917", reported[0])
+
+    def test_accepts_a_catalog_ahead_of_the_published_version(self) -> None:
+        reported = drift.findings(
+            catalog(("2.727.1199", 2628, True)),
+            sources("2.727.1199"),
+            ("2.725.1142", 2546),
+        )
+        self.assertEqual(reported, [])
+
+    def test_ignores_pinned_sources_for_another_architecture(self) -> None:
+        manifest = sources("2.727.1199")
+        manifest["sources"][0]["abi"] = "arm64-v8a"
+        reported = drift.findings(
+            catalog(("2.727.1199", 2628, True)), manifest, None
+        )
+        self.assertEqual(len(reported), 1)
+
+
+class MainTest(unittest.TestCase):
+    def test_exits_non_zero_on_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "catalog.json").write_text(
+                json.dumps(catalog(("2.727.1199", 2628, True)))
+            )
+            (root / "sources.json").write_text(json.dumps(sources()))
+            self.assertEqual(
+                drift.main(
+                    [
+                        "--catalog", str(root / "catalog.json"),
+                        "--sources", str(root / "sources.json"),
+                    ]
+                ),
+                1,
+            )
+
+    def test_reports_a_broken_manifest_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "catalog.json").write_text("{")
+            (root / "sources.json").write_text(json.dumps(sources()))
+            self.assertEqual(
+                drift.main(
+                    [
+                        "--catalog", str(root / "catalog.json"),
+                        "--sources", str(root / "sources.json"),
+                    ]
+                ),
+                2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/native_update_helper_fixture.cc
+++ b/tests/native_update_helper_fixture.cc
@@ -2,6 +2,7 @@
 #include <unistd.h>
 
 #include <charconv>
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <string>
@@ -47,6 +48,12 @@ int main(int argc, char** argv) {
     std::ofstream output(argument_capture);
     output << argv[2] << '\n';
     if (!output) return 67;
+  }
+  const char* diagnostics = Environment("MOCKTAIL_TEST_UPDATE_STDERR");
+  if (diagnostics[0] != '\0') {
+    std::fputs(diagnostics, stderr);
+    std::fputc('\n', stderr);
+    std::fflush(stderr);
   }
   const int progress = IntegerEnvironment("MOCKTAIL_UPDATE_PROGRESS_FD", -1);
   if (progress >= 0) {

--- a/tests/payload_update_preflight_test.cc
+++ b/tests/payload_update_preflight_test.cc
@@ -265,5 +265,46 @@ TEST(PayloadUpdatePreflightTest, PropagatesUpdaterFailure) {
   EXPECT_EQ(result.error, "Roblox update preflight failed");
 }
 
+TEST(PayloadUpdatePreflightTest, ReportsUpdaterFailureDetails) {
+  ScopedVariable exit_variable("MOCKTAIL_TEST_UPDATE_EXIT", "1");
+  ScopedVariable stderr_variable(
+      "MOCKTAIL_TEST_UPDATE_STDERR",
+      "[native-updater] latest Roblox failed probation (api.pureapk.com "
+      "request returned status 503)");
+  const MapEnvironment environment = NativeEnvironment();
+  const RuntimePaths paths = RuntimePaths::FromEnvironment(environment);
+  const auto result = RunPayloadUpdatePreflight(environment, paths);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.error, "Roblox update preflight failed");
+  EXPECT_EQ(result.details,
+            "latest Roblox failed probation (api.pureapk.com request returned "
+            "status 503)");
+}
+
+TEST(PayloadUpdatePreflightTest, KeepsLastUpdaterFailureOverWarnings) {
+  ScopedVariable exit_variable("MOCKTAIL_TEST_UPDATE_EXIT", "1");
+  ScopedVariable stderr_variable(
+      "MOCKTAIL_TEST_UPDATE_STDERR",
+      "[native-updater] warning: configuration key is unknown\n"
+      "unrelated diagnostic line\n"
+      "[native-updater] supported fallback also failed");
+  const MapEnvironment environment = NativeEnvironment();
+  const RuntimePaths paths = RuntimePaths::FromEnvironment(environment);
+  const auto result = RunPayloadUpdatePreflight(environment, paths);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.details, "supported fallback also failed");
+}
+
+TEST(PayloadUpdatePreflightTest, LeavesDetailsEmptyWhenUpdaterSucceeds) {
+  ScopedVariable stderr_variable(
+      "MOCKTAIL_TEST_UPDATE_STDERR",
+      "[native-updater] installed exact-supported Roblox 2.727.1199 (2628)");
+  const MapEnvironment environment = NativeEnvironment();
+  const RuntimePaths paths = RuntimePaths::FromEnvironment(environment);
+  const auto result = RunPayloadUpdatePreflight(environment, paths);
+  ASSERT_TRUE(result) << result.error;
+  EXPECT_TRUE(result.details.empty());
+}
+
 }  // namespace
 }  // namespace mocktail::runtime

--- a/tests/runtime_config_file_test.cc
+++ b/tests/runtime_config_file_test.cc
@@ -170,7 +170,11 @@ TEST(RuntimeConfigBootstrapTest,
            "payload is\n  "
            "# preserved when probation fails.\n  "
            "automatic: true",
-           "# String (default: apk-pure): direct x86_64 APK provider.\n  "
+           "# String (default: apk-pure): direct x86_64 APK provider "
+           "selection. Both\n  "
+           "# accepted values resolve the provider chain, which currently "
+           "starts with\n  "
+           "# APKPure. Supported values: auto, apk-pure.\n  "
            "source: apk-pure",
            "# Reserved for desktop update integrations. `mocktail_updater` "
            "itself never\n  # launches another process after changing the "


### PR DESCRIPTION
A clean first launch of 1.0.3 on a Steam Deck ended on
`Mocktail could not update or verify the Roblox installation.` and nothing else.
The cause was an APKPure outage (503 on every request, including unrelated
packages; it has since recovered). Three commits, each independent:

### 1. Report why the Roblox update preflight failed

The reason a first launch failed only ever reached the session log, and even
there `"HTTPS request returned status 503"` named no host.

- HTTP transfer failures now name the host: `api.pureapk.com request returned
  status 503`.
- The updater runs as a child process, so its stderr is now relayed through the
  launcher. Every line still reaches the session log unchanged; the last failure
  it reported is attached to the preflight result, and the dialog shows that
  reason plus the session log directory.

The relay drains the pipe before `waitpid` so a child that fills it cannot
deadlock the launcher, and the captured text is trimmed on a UTF-8 character
boundary because the dialog helper validates encoding and would otherwise fall
back to the generic sentence.

### 2. Resolve APK providers through a replaceable chain

`ApkPureProvider` was constructed directly in `RunUpdate`, `RunUnsafeLatest`, and
`ResolveReference`, and any other `updates.source` was rejected outright, so one
unreachable host failed the whole update with no second attempt.

- New `ApkProvider` interface and `ProviderChain`: consults providers in order,
  returns the first answer, and reports every failure prefixed with the provider
  that produced it when none answer.
- Each provider downloads into its own directory, so a failed attempt cannot
  block the next.
- Payload receipts record which provider produced an archive.
- `updates.source` accepts `auto` alongside `apk-pure`; existing configuration
  files keep working.

The chain holds APKPure alone on purpose. The pinned Uptodown provider that
already ships as a build script no longer works against Uptodown's current
pages, so wiring it in would add a second way to fail rather than a fallback — I
opened a separate issue for that rather than papering over it here.

### 3. Watch for drift in the pinned Roblox payload metadata

`scripts/check_payload_source_drift.py` reports when the compatibility catalog
falls behind the published version, or when the preferred supported profile has
no pinned bootstrap source. A daily workflow keeps one tracking issue current
instead of commenting every day.

This also runs the existing `tests/*_test.py` in CI, where they were never
executed.

Run against `main` today the checker already reports real drift: the preferred
profile 2.727.1199 has no pinned bootstrap source. Pinning one means downloading
and hashing the archive, and a newer profile also needs a graphics canary on real
hardware, so the checker reports the condition instead of pretending to fix it.

### Verification

- `ctest`: 816 of 831 pass. The 15 failures are all `_NOT_BUILT` targets and
  tests that need the `mocktail` binary, which could not link in my environment
  because webkitgtk-6.0, SDL3_ttf, and libutf8proc are not installed there. The
  compile errors are in `src/webview/webview_helper_policy.h`,
  `src/runtime/roblox_text_*.cc`, and `src/runtime/roblox_input_native_adapter.cc`,
  none of which these commits touch. I did not run a control build on an
  unmodified tree to confirm the same 15 fail there.
- `tests/*_test.py`: 52 pass, 8 skipped.
- Shell and JSON contract checks, `managed_payload_build_contract_test.sh`,
  `flatpak_packaging_test.sh`, `native_packaging_test.sh`, and
  `update_config_test.sh` all pass.
- End to end against the live provider, `mocktail_updater check-latest` built
  from this branch reports `2.734.917 2908`.
- I could not verify a packaged Flatpak or AppImage build locally, for the same
  missing-dependency reason. CI covers that.