### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ make build
 ./build/mocktail
 ```
 
+## Known limitations
+
+Mocktail does not currently work with `hardened_malloc`. Using
+`hardened_malloc` may cause Mocktail to fail to start or crash during runtime.
+Run Mocktail without `hardened_malloc` enabled.
+
 ## License
 
 [Apache License 2.0](LICENSE). Third-party components keep their own licenses.


### PR DESCRIPTION
Secureblue and user-hardened setups that LD_PRELOAD hardened_malloc or possibly other hardened memory allocators like scudo or mimalloc may or may not crash mocktail on runtime. hardened_malloc is verified to do so.