### PR TITLE
Add Nix development shell in flake and direnv support with 'use flake'

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ Testing/
 CMakeUserPresets.json
 *.cmake.user
 
+# local direnv development shell cache
+.direnv/
+
+# clangd cache
+.cache
+
 *.o
 *.obj
 *.a

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Description for the project";
+  description = "Experimental Roblox compatibility runtime for Linux and FreeBSD";
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
@@ -23,8 +23,39 @@
           pkgs,
           ...
         }:
+        let
+          package = pkgs.callPackage ./packaging/nix/package.nix { };
+        in
         {
-          packages.default = pkgs.callPackage ./packaging/nix/package.nix { };
+          packages.default = package;
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ package ];
+
+            # nixpkgs installs the header we need under include/libutf8proc
+            NIX_CFLAGS_COMPILE = "-I${pkgs.libutf8proc}/include/libutf8proc";
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              git
+              lld
+              ninja
+              pkg-config
+              vulkan-headers
+
+              llvmPackages_22.clang-tools
+              llvmPackages_22.libclang
+
+              # debugging
+              gdb
+            ];
+
+            shellHook = ''
+              export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath package.buildInputs}"
+
+              # nix packages graphics drivers differently, and mocktail will still work if it cannot guarantee symbols
+              export MOCKTAIL_REQUIRE_REAL_GRAPHICS=0
+            '';
+          };
         };
       flake = { };
     };


### PR DESCRIPTION
Direnv allows the project environment to be automatically applied when the project is cd'd into.

Other notable changes:
- .gitignore: add .cache and .direnv generated by clangd and direnv respectively

Sorry for not adding this in the first pull request!