### PR TITLE
fix(auth): fix login challenge interception and add clean first-launch sign-in flow

### DIFF
--- a/include/runtime/auth_runtime_composition.h
+++ b/include/runtime/auth_runtime_composition.h
@@ -1,6 +1,7 @@
 #ifndef MOCKTAIL_RUNTIME_AUTH_RUNTIME_COMPOSITION_H_
 #define MOCKTAIL_RUNTIME_AUTH_RUNTIME_COMPOSITION_H_
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -97,6 +98,10 @@ AuthRuntimeComposition ComposeAuthRuntime(
     const Environment& environment, const RuntimePaths& paths,
     services::AuthService& auth_service,
     std::shared_ptr<services::HttpClient> live_auth_http_client);
+
+// Persists a raw or prefixed Roblox credential to the given cookie file atomically.
+bool PersistRobloxCookie(const std::filesystem::path& path,
+                         std::string_view cookie_value);
 
 }  // namespace runtime
 }  // namespace mocktail

--- a/src/jnivm/jnivm.cc
+++ b/src/jnivm/jnivm.cc
@@ -5015,6 +5015,12 @@ void VM::ClearRobloxCredentialProvider() {
 
 bool VM::CopyRobloxCredentialFromProvider(std::string* credential) const {
   std::lock_guard<std::mutex> lock(roblox_credential_provider_mutex_);
+  if (!roblox_credential_override_.empty()) {
+    if (credential != nullptr) {
+      credential->assign(roblox_credential_override_);
+    }
+    return true;
+  }
   if (roblox_credential_provider_ == nullptr) {
     if (credential != nullptr) {
       credential->clear();
@@ -5022,10 +5028,6 @@ bool VM::CopyRobloxCredentialFromProvider(std::string* credential) const {
     return false;
   }
   if (credential == nullptr) {
-    return true;
-  }
-  if (!roblox_credential_override_.empty()) {
-    credential->assign(roblox_credential_override_);
     return true;
   }
   const RobloxCredentialView view =
@@ -5109,10 +5111,8 @@ bool VM::DispatchRobloxCredential(const char* data, std::size_t size) {
   std::string accepted(data, size);
   {
     std::lock_guard<std::mutex> lock(roblox_credential_provider_mutex_);
-    if (roblox_credential_provider_ != nullptr) {
-      ClearCookieString(&roblox_credential_override_);
-      roblox_credential_override_ = std::move(accepted);
-    }
+    ClearCookieString(&roblox_credential_override_);
+    roblox_credential_override_ = std::move(accepted);
   }
   ClearCookieString(&accepted);
   return true;

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,14 +1,17 @@
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -42,6 +45,7 @@
 #include "runtime/support_bundle.h"
 #include "runtime/supported_launch_policy.h"
 #include "runtime/system_proxy.h"
+#include "runtime/webview_helper_launcher.h"
 #include "services/auth_service.h"
 #include "services/browser_tracker_service.h"
 #include "services/client_settings_service.h"
@@ -100,6 +104,110 @@ mocktail::Status ShutdownPlatformBridges(jnivm::VM* vm) {
   }
   vm->ClearAndroidWindowCallbacks();
   return mocktail::audio::ShutdownFmodJniAudioBridge(vm);
+}
+
+void PromptFirstLaunchSignIn(
+    const mocktail::runtime::ProcessEnvironment& environment,
+    const mocktail::runtime::RuntimePaths& paths,
+    mocktail::services::AuthService& auth_service,
+    const std::shared_ptr<mocktail::services::HttpClient>& http_client,
+    mocktail::runtime::AuthRuntimeComposition* composition) {
+  if (composition == nullptr ||
+      composition->status != mocktail::runtime::AuthRuntimeStatus::kGuest ||
+      environment.Get("MOCKTAIL_GUEST") == "1" ||
+      environment.Get("MOCKTAIL_SKIP_FIRST_LAUNCH_LOGIN") == "1") {
+    return;
+  }
+
+  std::filesystem::path helper;
+  const char* helper_override = std::getenv("MOCKTAIL_WEBVIEW_HELPER");
+  if (helper_override != nullptr && helper_override[0] != '\0') {
+    helper = helper_override;
+  } else {
+    std::error_code error;
+    const std::filesystem::path executable =
+        std::filesystem::read_symlink("/proc/self/exe", error);
+    if (!error && !executable.empty()) {
+      helper = executable.parent_path() / "mocktail_webview_helper";
+    }
+  }
+  if (helper.empty() || !std::filesystem::exists(helper)) {
+    return;
+  }
+
+  std::cout << "\n======================================================\n"
+            << "  First-Time Setup: Roblox Sign-In\n"
+            << "======================================================\n"
+            << "  [auth] no saved session found; opening desktop sign-in window...\n"
+            << "  [auth] tip: you can use Quick Log In (QR code) or username/password\n"
+            << "  [auth] (close the sign-in window to play as guest)\n\n";
+
+  struct FirstLaunchContext {
+    std::mutex mutex;
+    std::string captured_cookie;
+    bool finished = false;
+  };
+  auto context = std::make_shared<FirstLaunchContext>();
+
+  mocktail::runtime::WebViewHelperExitObserver exit_observer;
+  exit_observer.context = context;
+  exit_observer.on_exit = [](void* ctx) {
+    auto* c = static_cast<FirstLaunchContext*>(ctx);
+    std::lock_guard<std::mutex> lock(c->mutex);
+    c->finished = true;
+  };
+
+  const auto launched = mocktail::runtime::LaunchWebViewHelper(
+      helper, "https://www.roblox.com/login", exit_observer);
+  if (!launched || launched.process == nullptr) {
+    return;
+  }
+  if (!launched.process->WaitUntilReady(std::chrono::milliseconds(5000))) {
+    (void)launched.process->RequestClose();
+    return;
+  }
+  (void)launched.process->SetRobloxCookie("");
+  (void)launched.process->SetTitle("Roblox sign in");
+  (void)launched.process->SetVisible(true);
+
+  std::vector<mocktail::runtime::WebViewHelperEvent> events;
+  while (true) {
+    {
+      std::lock_guard<std::mutex> lock(context->mutex);
+      if (context->finished) {
+        break;
+      }
+    }
+    if (launched.process->DrainEvents(&events)) {
+      for (const auto& event : events) {
+        if (event.type ==
+            mocktail::runtime::WebViewHelperEventType::kRobloxCookie) {
+          std::lock_guard<std::mutex> lock(context->mutex);
+          context->captured_cookie = event.payload;
+          (void)launched.process->RequestClose();
+          break;
+        }
+      }
+      events.clear();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  }
+
+  if (!context->captured_cookie.empty()) {
+    if (mocktail::runtime::PersistRobloxCookie(paths.cookie_file(),
+                                               context->captured_cookie)) {
+      mocktail::runtime::AuthRuntimeComposition new_comp =
+          mocktail::runtime::ComposeAuthRuntime(environment, paths,
+                                                auth_service, http_client);
+      if (new_comp.status ==
+          mocktail::runtime::AuthRuntimeStatus::kAuthenticated) {
+        *composition = std::move(new_comp);
+        std::cout << "  [auth] desktop sign-in successful; launching authenticated session\n";
+      }
+    }
+  } else {
+    std::cout << "  [auth] desktop sign-in window closed; continuing as guest\n";
+  }
 }
 
 }  // namespace
@@ -743,6 +851,12 @@ int main(int argc, char* argv[]) {
     mocktail::runtime::AuthRuntimeComposition composition =
         mocktail::runtime::ComposeAuthRuntime(environment, paths, auth_service,
                                               http_client);
+    if (!external_launch_request.has_value() &&
+        command_line.options.window_mode !=
+            mocktail::runtime::WindowMode::kHeadless) {
+      PromptFirstLaunchSignIn(environment, paths, auth_service, http_client,
+                              &composition);
+    }
     if (!composition) {
       std::cerr << "[FATAL] Typed Roblox authentication preflight failed: "
                 << composition.error;

--- a/src/runtime/auth_runtime_composition.cc
+++ b/src/runtime/auth_runtime_composition.cc
@@ -766,6 +766,23 @@ void ClearSensitiveString(std::string* value) {
 
 }  // namespace
 
+bool PersistRobloxCookie(const std::filesystem::path& path,
+                         std::string_view cookie_value) {
+  if (cookie_value.empty()) {
+    return false;
+  }
+  std::string formatted;
+  constexpr std::string_view kPrefix = ".ROBLOSECURITY=";
+  if (cookie_value.compare(0, kPrefix.size(), kPrefix) != 0) {
+    formatted = std::string(kPrefix) + std::string(cookie_value) + "\n";
+  } else {
+    formatted = std::string(cookie_value) + "\n";
+  }
+  const bool result = WritePrivateFileAtomically(path, formatted);
+  ClearSensitiveString(&formatted);
+  return result;
+}
+
 void SecurelyClearString(std::string* value) { ClearSensitiveString(value); }
 
 SecureRobloxCredential::SecureRobloxCredential(std::string canonical_header) {

--- a/src/runtime/roblox_web_view_bridge.cc
+++ b/src/runtime/roblox_web_view_bridge.cc
@@ -35,16 +35,62 @@ constexpr char kConnectionPointerField[] = "a";
 constexpr std::size_t kMaximumPendingHostWindowEvents = 256;
 constexpr std::string_view kBrowserLoginUrl = "https://www.roblox.com/login";
 
-bool IsLoginCaptchaUrl(std::string_view url) {
-  constexpr std::string_view kHttpsPrefix =
-      "https://www.roblox.com/captcha/app/login";
-  constexpr std::string_view kInternalPrefix = "www:captcha/app/login";
-  const auto matches = [url](std::string_view prefix) {
-    return url.compare(0, prefix.size(), prefix) == 0 &&
-           (url.size() == prefix.size() || url[prefix.size()] == '?' ||
-            url[prefix.size()] == '#');
+bool EqualsIgnoreCase(std::string_view a, std::string_view b) {
+  if (a.size() != b.size()) return false;
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(a[i])) !=
+        std::tolower(static_cast<unsigned char>(b[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool StartsWithIgnoreCase(std::string_view text, std::string_view prefix) {
+  if (text.size() < prefix.size()) return false;
+  return EqualsIgnoreCase(text.substr(0, prefix.size()), prefix);
+}
+
+bool IsLoginChallengeUrl(std::string_view url) {
+  std::string_view normalized = url;
+  if (StartsWithIgnoreCase(normalized, "https://www.roblox.com/")) {
+    normalized.remove_prefix(23);
+  } else if (StartsWithIgnoreCase(normalized, "https://roblox.com/")) {
+    normalized.remove_prefix(19);
+  } else if (StartsWithIgnoreCase(normalized, "https://apis.roblox.com/")) {
+    normalized.remove_prefix(24);
+  } else if (StartsWithIgnoreCase(normalized, "https://arkose.roblox.com/")) {
+    normalized.remove_prefix(26);
+  } else if (StartsWithIgnoreCase(normalized, "www:")) {
+    normalized.remove_prefix(4);
+  } else if (!normalized.empty() && normalized.front() == '/') {
+    normalized.remove_prefix(1);
+  }
+
+  constexpr std::string_view kChallengePrefixes[] = {
+      "captcha",
+      "view-generic-challenge",
+      "generic-challenge",
+      "login/challenge",
+      "challenge",
+      "arkose",
+      "login/twostepverification",
+      "twostepverification",
+      "login/two-step-verification",
+      "two-step-verification",
+      "reauthenticate",
   };
-  return matches(kHttpsPrefix) || matches(kInternalPrefix);
+
+  for (const std::string_view prefix : kChallengePrefixes) {
+    if (StartsWithIgnoreCase(normalized, prefix) &&
+        (normalized.size() == prefix.size() ||
+         normalized[prefix.size()] == '/' ||
+         normalized[prefix.size()] == '?' ||
+         normalized[prefix.size()] == '#')) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Status Invalid(std::string message) {
@@ -1161,7 +1207,7 @@ Status RobloxWebViewBridge::DispatchOpenRequest(
   if (!status.ok()) {
     return status;
   }
-  const bool browser_login_fallback = IsLoginCaptchaUrl(request.url);
+  const bool browser_login_fallback = IsLoginChallengeUrl(request.url);
   if (browser_login_fallback) {
     request.url = kBrowserLoginUrl;
     request.title = "Roblox sign in";

--- a/src/webview/mocktail_webview_helper.cc
+++ b/src/webview/mocktail_webview_helper.cc
@@ -318,10 +318,23 @@ bool IsRobloxCookieDomain(const char* domain) {
 }
 
 bool IsBrowserLoginUrl(std::string_view url) {
-  constexpr std::string_view kLoginUrl = "https://www.roblox.com/login";
-  return url.compare(0, kLoginUrl.size(), kLoginUrl) == 0 &&
-         (url.size() == kLoginUrl.size() || url[kLoginUrl.size()] == '?' ||
-          url[kLoginUrl.size()] == '#');
+  std::string_view normalized = url;
+  if (normalized.compare(0, 23, "https://www.roblox.com/") == 0) {
+    normalized.remove_prefix(23);
+  } else if (normalized.compare(0, 19, "https://roblox.com/") == 0) {
+    normalized.remove_prefix(19);
+  } else if (normalized.compare(0, 4, "www:") == 0) {
+    normalized.remove_prefix(4);
+  } else if (!normalized.empty() && normalized.front() == '/') {
+    normalized.remove_prefix(1);
+  }
+  constexpr std::string_view kLogin = "login";
+  return (normalized.compare(0, kLogin.size(), kLogin) == 0 ||
+          normalized.compare(0, kLogin.size(), "Login") == 0) &&
+         (normalized.size() == kLogin.size() ||
+          normalized[kLogin.size()] == '/' ||
+          normalized[kLogin.size()] == '?' ||
+          normalized[kLogin.size()] == '#');
 }
 
 void FinishRobloxCookieQuery(GObject* source, GAsyncResult* result,
@@ -801,6 +814,10 @@ void OnLoadChanged(WebKitWebView* web_view, WebKitLoadEvent event,
             << " scheme=" << policy.scheme << " host=" << policy.host << '\n';
   if (event == WEBKIT_LOAD_COMMITTED || event == WEBKIT_LOAD_FINISHED) {
     UpdateDomainTitle(web_view, static_cast<SurfaceState*>(user_data));
+    auto* surface = static_cast<SurfaceState*>(user_data);
+    if (surface != nullptr && surface->app != nullptr) {
+      RequestRobloxCookie(surface->app);
+    }
   }
 }
 

--- a/tests/auth_runtime_composition_test.cc
+++ b/tests/auth_runtime_composition_test.cc
@@ -865,6 +865,52 @@ TEST(AuthRuntimeCompositionTest,
       dependencies.jni_vm()->CopyRobloxCredentialFromProvider(nullptr));
 }
 
+TEST(AuthRuntimeCompositionTest,
+     GuestRuntimePromotesDispatchedCredentialAndExposesToJava) {
+  const TempDirectory directory;
+  MapEnvironment environment;
+  environment.Set("HOME", directory.path().string());
+  environment.Set("MOCKTAIL_ALLOW_NO_COOKIE_LUA_APP", "1");
+  auto http = std::make_shared<FakeHttpClient>();
+  http->response = {
+      true,
+      200,
+      R"({"id":999,"name":"GuestPromotedUser","displayName":"GuestPromoted"})",
+      {}};
+  services::AuthService auth_service(*http);
+  AuthRuntimeComposition composition = ComposeAuthRuntime(
+      environment, PathsFor(environment, directory), auth_service, http);
+  ASSERT_TRUE(composition);
+  EXPECT_EQ(composition.status, AuthRuntimeStatus::kGuest);
+
+  std::shared_ptr<jnivm::VM> vm = composition.jni_vm;
+  ASSERT_NE(vm, nullptr);
+  EXPECT_EQ(vm->GetRobloxAuthIdentitySnapshot().user_id, -1);
+
+  const std::string dispatched_header =
+      std::string(".ROBLOSECURITY=") + kCredential;
+  EXPECT_TRUE(vm->DispatchRobloxCredential(dispatched_header.c_str(),
+                                           dispatched_header.size()));
+
+  const jnivm::RobloxAuthIdentity promoted_identity =
+      vm->GetRobloxAuthIdentitySnapshot();
+  EXPECT_EQ(promoted_identity.user_id, 999);
+  EXPECT_EQ(promoted_identity.username, "GuestPromotedUser");
+
+  std::string read_credential;
+  EXPECT_TRUE(vm->CopyRobloxCredentialFromProvider(&read_credential));
+  EXPECT_EQ(read_credential, dispatched_header);
+
+  JNIEnv* env = vm->GetJNIEnv();
+  jclass cookie_manager =
+      env->FindClass("com/roblox/universalapp/cookie/JNICookieManager");
+  jmethodID get_cookie = env->GetStaticMethodID(
+      cookie_manager, "getCookie", "(Ljava/lang/String;)Ljava/lang/String;");
+  auto java_cookie = static_cast<jstring>(env->CallStaticObjectMethod(
+      cookie_manager, get_cookie, env->NewStringUTF("roblox.com")));
+  EXPECT_EQ(ReadJavaString(env, java_cookie), dispatched_header);
+}
+
 }  // namespace
 }  // namespace runtime
 }  // namespace mocktail

--- a/tests/roblox_web_view_bridge_test.cc
+++ b/tests/roblox_web_view_bridge_test.cc
@@ -705,6 +705,48 @@ TEST(RobloxWebViewBridgeTest,
   g_web_view_probe = nullptr;
 }
 
+TEST(RobloxWebViewBridgeTest,
+     RoutesGenericChallengesAndApiChallengesToBrowserSignIn) {
+  jnivm::VM vm;
+  JNIEnv* env = vm.GetJNIEnv();
+  jclass bus_class =
+      env->FindClass("com/roblox/universalapp/messagebus/MessageBus");
+  jobject bus = env->AllocObject(bus_class);
+  WebViewBridgeProbe probe;
+  g_web_view_probe = &probe;
+  RobloxWebViewBridge bridge = MakeBridge(&vm, bus, &probe);
+  ASSERT_TRUE(bridge.Initialize().ok());
+
+  ASSERT_TRUE(
+      bridge
+          .HandleOwnedMessage(
+              R"({"url":"https://www.roblox.com/view-generic-challenge?subdomain=login"})")
+          .ok());
+  EXPECT_EQ(probe.request.url, "https://www.roblox.com/login");
+  EXPECT_EQ(probe.request.title, "Roblox sign in");
+  EXPECT_TRUE(bridge.HandleCloseWindow().ok());
+  EXPECT_EQ(probe.close_dispatches, 0);
+  probe.exit_observer.on_exit(probe.exit_observer.context.get());
+  ASSERT_TRUE(bridge.DrainHostWindowEvents().ok());
+  EXPECT_EQ(probe.close_publications, 1);
+
+  ASSERT_TRUE(
+      bridge
+          .HandleOwnedMessage(
+              R"({"url":"https://apis.roblox.com/challenge/v1/render?type=captcha"})")
+          .ok());
+  EXPECT_EQ(probe.request.url, "https://www.roblox.com/login");
+  EXPECT_EQ(probe.request.title, "Roblox sign in");
+  EXPECT_TRUE(bridge.HandleCloseWindow().ok());
+  EXPECT_EQ(probe.close_dispatches, 0);
+  probe.exit_observer.on_exit(probe.exit_observer.context.get());
+  ASSERT_TRUE(bridge.DrainHostWindowEvents().ok());
+  EXPECT_EQ(probe.close_publications, 2);
+
+  EXPECT_TRUE(bridge.Shutdown().ok());
+  g_web_view_probe = nullptr;
+}
+
 TEST(RobloxWebViewBridgeTest, MainGameActivityOpensThroughHostSink) {
   jnivm::VM vm;
   JNIEnv* env = vm.GetJNIEnv();


### PR DESCRIPTION
## Summary

Fixes the login challenge failure (black screen / frozen spinner) on Linux and introduces a clean first-launch desktop sign-in flow.

### Root Cause
1. When submitting credentials in the mobile/in-app UI, Roblox returns `403 Forbidden` (`{"errors":[{"code":0,"message":"Challenge is required to authorize the request"}]}`).
2. Luau emits `Rendering generic challenge` with Android Play Integrity attestation requirements (`integrityType: "playintegrity"`).
3. On desktop Linux, Android Play Integrity cannot be satisfied, causing Luau to immediately emit `Load generic challenge failed` and close the native window within ~100ms, leaving the user stuck on a black modal overlay.
4. `IsLoginCaptchaUrl` in `RobloxWebViewBridge` was only matching `/captcha/app/login` routes and not generic challenge routes (`view-generic-challenge`, `generic-challenge`, etc.), causing fallback browser sign-in to be bypassed and the window closed prematurely.
5. In guest mode without an initial credential provider, `VM::DispatchRobloxCredential` was not preserving late-promoted session credentials for JNI queries.

### Key Changes
- **Comprehensive Challenge URL Recognition (`src/runtime/roblox_web_view_bridge.cc`)**:
  - Replaced `IsLoginCaptchaUrl` with `IsLoginChallengeUrl` matching generic challenges, 2FA, Arkose, and re-authentication routes (`view-generic-challenge`, `generic-challenge`, `challenge`, `captcha`, `login/challenge`, `twostepverification`, `two-step-verification`, `reauthenticate`, `arkose`).
  - Keeps browser login window open (`keep_browser_login_open`) until user authentication completes.
- **Clean First-Launch Sign-In (`src/main.cc`)**:
  - On fresh sessions without a saved cookie, Mocktail presents the lightweight desktop WebKit sign-in window before initializing the heavy 3D Vulkan engine.
  - Sends cookie synchronization handshake (`SetRobloxCookie("")`) to begin page navigation immediately.
  - Automatically captures `.ROBLOSECURITY` and writes to `~/.local/share/mocktail/cookie` with `0600` permissions via `PersistRobloxCookie`.
- **Dynamic Guest Session Promotion (`src/jnivm/jnivm.cc`, `src/runtime/auth_runtime_composition.cc`)**:
  - Ensures runtime-dispatched session cookies are stored and returned to JNI even when started in guest mode without a pre-existing credential provider.
- **Unit Tests (`tests/auth_runtime_composition_test.cc`, `tests/roblox_web_view_bridge_test.cc`)**:
  - Added unit test suites verifying generic challenge routing, browser sign-in URL normalization, and guest credential promotion.