### PR TITLE
fix(app-policy): clear the regional "unchecked" badge in the desktop …

### DIFF
--- a/src/runtime/roblox_desktop_app_policy.cc
+++ b/src/runtime/roblox_desktop_app_policy.cc
@@ -189,6 +189,7 @@ void NormalizeDesktopLayout(nlohmann::json* policy) {
   (*policy)["SystemBarPlacement"] = "Left";
   (*policy)["ShouldSystemBarUsuallyBePresent"] = true;
   (*policy)["DevicePreferencesPersistentPresenceVariant"] = "windows";
+  (*policy)["ShowUncheckedBadge"] = false;
 }
 
 bool DecodePolicy(const nlohmann::json& encoded, nlohmann::json* policy) {

--- a/tests/roblox_desktop_app_policy_test.cc
+++ b/tests/roblox_desktop_app_policy_test.cc
@@ -73,6 +73,7 @@ void ExpectDesktopLayout(const nlohmann::json& policy) {
   EXPECT_EQ(policy["SystemBarPlacement"], "Left");
   EXPECT_EQ(policy["ShouldSystemBarUsuallyBePresent"], true);
   EXPECT_EQ(policy["DevicePreferencesPersistentPresenceVariant"], "windows");
+  EXPECT_EQ(policy["ShowUncheckedBadge"], false);
 }
 
 TEST(RobloxDesktopAppPolicyTest,
@@ -86,7 +87,7 @@ TEST(RobloxDesktopAppPolicyTest,
   const nlohmann::json original_policy = {
       {"PlatformGroup", "Unknown"},       {"UseGridHomePage", nullptr},
       {"SystemBarPlacement", "Bottom"},   {"EligibleForVideoCapture", false},
-      {"AccountOwnedMarker", "preserve"},
+      {"ShowUncheckedBadge", true},       {"AccountOwnedMarker", "preserve"},
   };
   const nlohmann::json configurations = {
       {"GUAC:42:app-policy", original_policy.dump()},


### PR DESCRIPTION
ApplyDesktopAppPolicy pins a whole app policy through FStringAppConfigurationOverrideAppPolicy so a later GUAC response cannot replace the desktop layout. On a first launch that snapshot is the APK's bundled GuacDefaultPolicy-GlobalDist.json, which ships "ShowUncheckedBadge": true.

Because the override is permanent, the account's own GUAC policy never gets a chance to correct it: on a signed-in profile the cached GUAC:-1:app-policy stays byte-identical to the bundled default plus the six keys NormalizeDesktopLayout writes.

In the UniversalApp bundle that field feeds getShowUncheckedBadge, which gates the UncheckedBadge element rendered next to the display name in the top-bar user-info widget and in the flyout profile card. Its label is CommonUI.Features.Label.Unchecked ("not verified"), so verified accounts are permanently marked unverified. The desktop chrome has no such badge.

Normalize it to false alongside the other layout fields, and cover it in the existing round-trip test.

<img width="459" height="102" alt="image" src="https://github.com/user-attachments/assets/92b6ded5-1bed-4832-869f-ca9834f4af26" />
