### PR TITLE
fix(graphics): size the texture budget from the host instead of the g…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ add_library(mocktail_runtime STATIC
   src/runtime/supported_launch_policy.cc
   src/runtime/support_bundle.cc
   src/runtime/system_proxy.cc
+  src/runtime/texture_memory_policy.cc
 )
 add_library(Mocktail::Runtime ALIAS mocktail_runtime)
 target_include_directories(mocktail_runtime PUBLIC include)

--- a/include/runtime/texture_memory_policy.h
+++ b/include/runtime/texture_memory_policy.h
@@ -1,0 +1,32 @@
+#ifndef MOCKTAIL_RUNTIME_TEXTURE_MEMORY_POLICY_H_
+#define MOCKTAIL_RUNTIME_TEXTURE_MEMORY_POLICY_H_
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace mocktail {
+namespace runtime {
+
+// Roblox sizes its texture budget for the Android guest, so a PC host still
+// gets caps.videoMemory = 64 MiB. These publish a host-sized budget through
+// Roblox's own FIntRenderForceVideoMemorySize override.
+
+// Total usable host memory in bytes, or 0 when it cannot be read.
+std::uint64_t DetectHostMemoryBytes();
+
+// 0 leaves Roblox's budget alone; otherwise an eighth of host memory, clamped
+// to a PC-class range.
+std::uint64_t CalculateTextureMemoryBudgetBytes(std::uint64_t host_memory_bytes);
+
+// A 0 budget, or a key already present, is preserved: an explicit fflags.json
+// or environment override wins.
+bool MergeTextureMemoryClientSettingsOverrides(std::uint64_t budget_bytes,
+                                               std::string_view base_json,
+                                               std::string* merged_json,
+                                               std::string* error);
+
+}  // namespace runtime
+}  // namespace mocktail
+
+#endif  // MOCKTAIL_RUNTIME_TEXTURE_MEMORY_POLICY_H_

--- a/src/runtime/performance_policy.cc
+++ b/src/runtime/performance_policy.cc
@@ -16,6 +16,7 @@
 
 #include "runtime/crash_report_policy.h"
 #include "runtime/http_client_policy.h"
+#include "runtime/texture_memory_policy.h"
 
 namespace mocktail {
 namespace runtime {
@@ -275,7 +276,13 @@ bool MergeRuntimeClientSettingsOverrides(const FrameRatePolicy& frame_rate,
                                         &http_client_overrides, error)) {
     return false;
   }
-  return MergeCrashReportClientSettingsOverrides(http_client_overrides,
+  std::string texture_memory_overrides;
+  if (!MergeTextureMemoryClientSettingsOverrides(
+          CalculateTextureMemoryBudgetBytes(DetectHostMemoryBytes()),
+          http_client_overrides, &texture_memory_overrides, error)) {
+    return false;
+  }
+  return MergeCrashReportClientSettingsOverrides(texture_memory_overrides,
                                                  merged_json, error);
 }
 

--- a/src/runtime/texture_memory_policy.cc
+++ b/src/runtime/texture_memory_policy.cc
@@ -1,0 +1,85 @@
+#include "runtime/texture_memory_policy.h"
+
+#define JSON_NOEXCEPTION 1
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace mocktail {
+namespace runtime {
+namespace {
+
+constexpr std::uint64_t kMebibyte = 1024U * 1024U;
+// Below this the guest default is already a reasonable share of the host.
+constexpr std::uint64_t kMinimumHostMemoryBytes = 4096U * kMebibyte;
+constexpr std::uint64_t kMinimumBudgetBytes = 256U * kMebibyte;
+constexpr std::uint64_t kMaximumBudgetBytes = 1536U * kMebibyte;
+constexpr std::string_view kVideoMemoryOverride =
+    "FIntRenderForceVideoMemorySize";
+
+}  // namespace
+
+std::uint64_t DetectHostMemoryBytes() {
+  std::ifstream input("/proc/meminfo");
+  std::string key;
+  while (input >> key) {
+    if (key != "MemTotal:") {
+      input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+      continue;
+    }
+    std::uint64_t kibibytes = 0;
+    if (!(input >> kibibytes)) {
+      break;
+    }
+    if (kibibytes > std::numeric_limits<std::uint64_t>::max() / 1024U) {
+      break;
+    }
+    return kibibytes * 1024U;
+  }
+  return 0;
+}
+
+std::uint64_t CalculateTextureMemoryBudgetBytes(
+    std::uint64_t host_memory_bytes) {
+  if (host_memory_bytes < kMinimumHostMemoryBytes) {
+    return 0;
+  }
+  return std::clamp(host_memory_bytes / 8U, kMinimumBudgetBytes,
+                    kMaximumBudgetBytes);
+}
+
+bool MergeTextureMemoryClientSettingsOverrides(std::uint64_t budget_bytes,
+                                               std::string_view base_json,
+                                               std::string* merged_json,
+                                               std::string* error) {
+  if (merged_json == nullptr) {
+    if (error != nullptr) {
+      *error = "texture memory client-settings output is required";
+    }
+    return false;
+  }
+  nlohmann::json overrides = nlohmann::json::parse(
+      base_json.empty() ? "{}" : base_json, nullptr, false, true);
+  if (overrides.is_discarded() || !overrides.is_object()) {
+    if (error != nullptr) {
+      *error = "texture memory client-settings input must be a JSON object";
+    }
+    return false;
+  }
+  const std::string key(kVideoMemoryOverride);
+  if (budget_bytes != 0 && !overrides.contains(key)) {
+    // The override is a Roblox FInt, so it cannot carry more than INT32_MAX.
+    const std::uint64_t clamped = std::min<std::uint64_t>(
+        budget_bytes,
+        static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()));
+    overrides[key] = std::to_string(clamped);
+  }
+  *merged_json = overrides.dump();
+  return true;
+}
+
+}  // namespace runtime
+}  // namespace mocktail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,12 @@ target_link_libraries(performance_policy_test PRIVATE
   GTest::gtest_main
 )
 
+add_executable(texture_memory_policy_test texture_memory_policy_test.cc)
+target_link_libraries(texture_memory_policy_test PRIVATE
+  Mocktail::Runtime
+  GTest::gtest_main
+)
+
 add_executable(http_client_policy_test http_client_policy_test.cc)
 target_link_libraries(http_client_policy_test PRIVATE
   Mocktail::Runtime
@@ -810,6 +816,7 @@ gtest_discover_tests(session_log_test)
 gtest_discover_tests(failure_dialog_test)
 gtest_discover_tests(frame_rate_policy_test)
 gtest_discover_tests(performance_policy_test)
+gtest_discover_tests(texture_memory_policy_test)
 gtest_discover_tests(http_client_policy_test)
 gtest_discover_tests(http_client_spin_guard_test)
 gtest_discover_tests(crash_report_policy_test)

--- a/tests/texture_memory_policy_test.cc
+++ b/tests/texture_memory_policy_test.cc
@@ -1,0 +1,94 @@
+#include "runtime/texture_memory_policy.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace mocktail {
+namespace runtime {
+namespace {
+
+constexpr std::uint64_t kMebibyte = 1024U * 1024U;
+
+TEST(TextureMemoryPolicyTest, LeavesTheGuestDefaultOnSmallHosts) {
+  EXPECT_EQ(CalculateTextureMemoryBudgetBytes(0), 0U);
+  EXPECT_EQ(CalculateTextureMemoryBudgetBytes(2048U * kMebibyte), 0U);
+  EXPECT_EQ(CalculateTextureMemoryBudgetBytes(4095U * kMebibyte), 0U);
+}
+
+TEST(TextureMemoryPolicyTest, SizesAClampedShareOfHostMemory) {
+  EXPECT_EQ(CalculateTextureMemoryBudgetBytes(4096U * kMebibyte),
+            512U * kMebibyte);
+  EXPECT_EQ(CalculateTextureMemoryBudgetBytes(8192U * kMebibyte),
+            1024U * kMebibyte);
+  // An eighth of a very large host stays inside the PC-class ceiling.
+  EXPECT_EQ(CalculateTextureMemoryBudgetBytes(65536U * kMebibyte),
+            1536U * kMebibyte);
+}
+
+TEST(TextureMemoryPolicyTest, PublishesTheBudgetWithoutDiscardingOverrides) {
+  std::string merged;
+  std::string error;
+  ASSERT_TRUE(MergeTextureMemoryClientSettingsOverrides(
+      1024U * kMebibyte,
+      R"({"FStringGraphicsVulkanShaderMTDenyPattern":"4318:.*"})", &merged,
+      &error))
+      << error;
+  const nlohmann::json parsed = nlohmann::json::parse(merged);
+  EXPECT_EQ(parsed.at("FIntRenderForceVideoMemorySize"),
+            std::to_string(1024U * kMebibyte));
+  EXPECT_EQ(parsed.at("FStringGraphicsVulkanShaderMTDenyPattern"), "4318:.*");
+}
+
+TEST(TextureMemoryPolicyTest, KeepsAnExplicitUserOverride) {
+  std::string merged;
+  std::string error;
+  ASSERT_TRUE(MergeTextureMemoryClientSettingsOverrides(
+      1024U * kMebibyte, R"({"FIntRenderForceVideoMemorySize":"64"})", &merged,
+      &error))
+      << error;
+  EXPECT_EQ(nlohmann::json::parse(merged).at("FIntRenderForceVideoMemorySize"),
+            "64");
+}
+
+TEST(TextureMemoryPolicyTest, ZeroBudgetPublishesNothing) {
+  std::string merged;
+  std::string error;
+  ASSERT_TRUE(MergeTextureMemoryClientSettingsOverrides(0, "{}", &merged,
+                                                        &error))
+      << error;
+  EXPECT_FALSE(
+      nlohmann::json::parse(merged).contains("FIntRenderForceVideoMemorySize"));
+}
+
+TEST(TextureMemoryPolicyTest, ClampsToTheFastVariableRange) {
+  std::string merged;
+  std::string error;
+  ASSERT_TRUE(MergeTextureMemoryClientSettingsOverrides(
+      8ULL * 1024U * kMebibyte, "{}", &merged, &error))
+      << error;
+  EXPECT_EQ(nlohmann::json::parse(merged).at("FIntRenderForceVideoMemorySize"),
+            std::to_string(std::numeric_limits<std::int32_t>::max()));
+}
+
+TEST(TextureMemoryPolicyTest, RejectsMalformedInput) {
+  std::string merged;
+  std::string error;
+  EXPECT_FALSE(MergeTextureMemoryClientSettingsOverrides(kMebibyte, "[]",
+                                                         &merged, &error));
+  EXPECT_FALSE(error.empty());
+  EXPECT_FALSE(MergeTextureMemoryClientSettingsOverrides(kMebibyte, "{}",
+                                                         nullptr, &error));
+}
+
+TEST(TextureMemoryPolicyTest, ReadsHostMemory) {
+  // /proc/meminfo is always present on the supported hosts.
+  EXPECT_GT(DetectHostMemoryBytes(), 0U);
+}
+
+}  // namespace
+}  // namespace runtime
+}  // namespace mocktail


### PR DESCRIPTION
…uest

Roblox sizes its resident texture budget for the Android guest. On a PC host the Vulkan backend still lands on

  VULKAN unifiedMemory = false, device memory = 5894524928,
  host memory = 2947260416, setting caps.videoMemory = 67108864

so the engine works with a 64 MiB texture budget even though the device advertises 5.5 GiB. TextureManager2 then keeps only the smallest mip levels resident: surfaces render blurred, and the SurfaceAppearance and material texture packs fail outright with

  Failed to load ...SurfaceAppearance. PBR textures may not be visible.
  Asset (Image) "" load failed in fetchTexturePackTextures: Request failed

which is why parts show up as flat untextured plastic.

Publish a host-sized budget through Roblox's own
FIntRenderForceVideoMemorySize override: an eighth of host memory, clamped to 256 MiB..1536 MiB, and only when the host has at least 4 GiB. The value is merged after fflags.json and the environment, so an explicit user override always wins.

Verified against the real client (Roblox 2.734.917, RADV VANGOGH): with the override present the engine reports the requested budget instead of the 64 MiB default, using the same string encoding LoadAndMergeFflagsFile produces.

<img width="824" height="650" alt="Capture d&#39;écran_20260826_105134" src="https://github.com/user-attachments/assets/6b72757c-7aeb-4c2e-b17f-28fbdcd6a835" />

Fix:
<img width="1343" height="838" alt="Capture d&#39;écran_20260826_111637" src="https://github.com/user-attachments/assets/df4df2ab-2da4-493e-90f2-65b9683e3c7e" />
