### PR TITLE
feat(ui): add a settings window reachable from the launcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,15 @@ add_executable(mocktail_failure_dialog
 target_link_libraries(mocktail_failure_dialog PRIVATE PkgConfig::LIBADWAITA)
 mocktail_apply_compile_options(mocktail_failure_dialog)
 
+add_executable(mocktail_settings
+  src/ui/mocktail_settings_window.cc
+)
+target_link_libraries(mocktail_settings PRIVATE
+  Mocktail::Runtime
+  PkgConfig::LIBADWAITA
+)
+mocktail_apply_compile_options(mocktail_settings)
+
 add_library(mocktail_services STATIC
   src/services/http_client.cc
   src/services/auth_service.cc
@@ -629,6 +638,7 @@ target_include_directories(mocktail PRIVATE include src)
 mocktail_apply_compile_options(mocktail)
 target_compile_definitions(mocktail PRIVATE
   "MOCKTAIL_DEFAULT_COMPATIBILITY_MANIFEST=\"${MOCKTAIL_DEFAULT_COMPATIBILITY_MANIFEST}\""
+  "MOCKTAIL_INSTALL_LIBDIR=\"${CMAKE_INSTALL_LIBDIR}\""
 )
 target_link_libraries(mocktail PRIVATE
   mocktail_legacy_runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ add_library(mocktail_runtime STATIC
   src/runtime/runtime_config.cc
   src/runtime/runtime_config_bootstrap.cc
   src/runtime/runtime_config_file.cc
+  src/runtime/runtime_config_writer.cc
   src/runtime/runtime_paths.cc
   src/runtime/session_log.cc
   src/runtime/single_instance_lock.cc

--- a/include/runtime/command_line.h
+++ b/include/runtime/command_line.h
@@ -10,6 +10,7 @@ namespace runtime {
 enum class CommandMode {
   kRun,
   kHelp,
+  kSettings,
 };
 
 enum class WindowMode {

--- a/include/runtime/runtime_config_writer.h
+++ b/include/runtime/runtime_config_writer.h
@@ -1,0 +1,43 @@
+#ifndef MOCKTAIL_RUNTIME_RUNTIME_CONFIG_WRITER_H_
+#define MOCKTAIL_RUNTIME_RUNTIME_CONFIG_WRITER_H_
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace mocktail {
+namespace runtime {
+
+// One `a.b.c` assignment. `value` is written verbatim; use EncodeConfigScalar
+// for free-form text.
+struct ConfigAssignment {
+  std::vector<std::string> path;
+  std::string value;
+};
+
+// Quotes only when a bare scalar would not round-trip.
+std::string EncodeConfigScalar(std::string_view value);
+
+// Rewrites the config line by line so comments, key order, and untouched
+// values survive; a YAML round-trip would discard every comment in it. A
+// missing key is inserted after its commented-out template when one exists,
+// otherwise at the end of its parent block.
+//
+// Fails instead of overwriting a key that opens a nested block: `device` may
+// be a preset string or a mapping, and flattening it would drop a custom
+// device profile.
+bool ApplyConfigAssignments(std::string_view yaml,
+                            const std::vector<ConfigAssignment>& assignments,
+                            std::string* updated, std::string* error);
+
+// Reads, rewrites, and atomically replaces the file at mode 0600. Refuses a
+// symlinked target.
+bool WriteConfigAssignments(const std::filesystem::path& config_file,
+                            const std::vector<ConfigAssignment>& assignments,
+                            std::string* error);
+
+}  // namespace runtime
+}  // namespace mocktail
+
+#endif  // MOCKTAIL_RUNTIME_RUNTIME_CONFIG_WRITER_H_

--- a/packaging/space.bigrat.mocktail.desktop
+++ b/packaging/space.bigrat.mocktail.desktop
@@ -9,4 +9,10 @@ StartupWMClass=space.bigrat.mocktail
 Categories=Game;
 Terminal=false
 MimeType=x-scheme-handler/roblox;x-scheme-handler/roblox-player;
+Actions=settings;
 X-Mocktail-Managed=true
+
+[Desktop Action settings]
+Name=Settings
+Exec=mocktail --settings
+Icon=space.bigrat.mocktail

--- a/scripts/register_url_handler.sh
+++ b/scripts/register_url_handler.sh
@@ -137,14 +137,18 @@ fi
   Die "cannot find the Mocktail desktop template; pass --desktop-file PATH"
 desktop_source="$(ResolveRegularFile "${desktop_source}" "desktop template")"
 
-[[ "$(grep -Fxc '[Desktop Entry]' "${desktop_source}")" == 1 &&
-   "$(grep -Fxc 'Type=Application' "${desktop_source}")" == 1 &&
-   "$(grep -Fxc 'Icon=space.bigrat.mocktail' "${desktop_source}")" == 1 &&
-   "$(grep -Fxc 'Exec=mocktail %u' "${desktop_source}")" == 1 &&
+# Desktop actions carry their own Exec and Icon keys, so the contract is
+# checked against the [Desktop Entry] section alone.
+entry_section="$(awk '/^\[/ { inside = ($0 == "[Desktop Entry]") } inside' \
+  "${desktop_source}")"
+[[ "$(grep -Fxc '[Desktop Entry]' <<<"${entry_section}")" == 1 &&
+   "$(grep -Fxc 'Type=Application' <<<"${entry_section}")" == 1 &&
+   "$(grep -Fxc 'Icon=space.bigrat.mocktail' <<<"${entry_section}")" == 1 &&
+   "$(grep -Fxc 'Exec=mocktail %u' <<<"${entry_section}")" == 1 &&
    "$(grep -Fxc 'MimeType=x-scheme-handler/roblox;x-scheme-handler/roblox-player;' \
-       "${desktop_source}")" == 1 &&
-   "$(grep -Fxc 'X-Mocktail-Managed=true' "${desktop_source}")" == 1 &&
-   "$(grep -c '^Exec=' "${desktop_source}")" == 1 ]] ||
+       <<<"${entry_section}")" == 1 &&
+   "$(grep -Fxc 'X-Mocktail-Managed=true' <<<"${entry_section}")" == 1 &&
+   "$(grep -c '^Exec=' <<<"${entry_section}")" == 1 ]] ||
   Die "desktop template does not match the Mocktail URL-handler contract"
 
 [[ -n "${HOME:-}" && "${HOME}" == /* ]] ||
@@ -171,15 +175,28 @@ fi
 
 temporary="$(mktemp "${applications_dir}/.${DESKTOP_ID}.XXXXXX.desktop")"
 trap 'rm -f -- "${temporary}"' EXIT
+section=""
 while IFS= read -r line || [[ -n "${line}" ]]; do
-  if [[ "${line}" == Exec=* ]]; then
-    printf 'Exec=%s %%u\n' "${mocktail_executable}"
-    if [[ -n "${launch_working_directory}" ]]; then
-      printf 'Path=%s\n' "${launch_working_directory}"
-    fi
-  else
+  if [[ "${line}" == '['*']' ]]; then
+    section="${line}"
     printf '%s\n' "${line}"
+    continue
   fi
+  if [[ "${line}" == Exec=* ]]; then
+    if [[ "${section}" == '[Desktop Entry]' ]]; then
+      printf 'Exec=%s %%u\n' "${mocktail_executable}"
+      if [[ -n "${launch_working_directory}" ]]; then
+        printf 'Path=%s\n' "${launch_working_directory}"
+      fi
+      continue
+    fi
+    # An action keeps its own arguments; only the program becomes absolute.
+    if [[ "${line}" == 'Exec=mocktail'* ]]; then
+      printf 'Exec=%s%s\n' "${mocktail_executable}" "${line#Exec=mocktail}"
+      continue
+    fi
+  fi
+  printf '%s\n' "${line}"
 done <"${desktop_source}" >"${temporary}"
 chmod 0644 "${temporary}"
 if command -v desktop-file-validate >/dev/null 2>&1; then

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
@@ -215,6 +217,39 @@ void PromptFirstLaunchSignIn(
   }
 }
 
+// Locates the settings window next to the runtime, mirroring how the failure
+// dialog helper is resolved so packaged and in-tree builds both work.
+std::filesystem::path ResolveSettingsHelper(
+    const mocktail::runtime::Environment& environment) {
+  const std::optional<std::string> override_path =
+      environment.Get("MOCKTAIL_SETTINGS_HELPER");
+  if (override_path.has_value()) {
+    const std::filesystem::path helper(*override_path);
+    return helper.is_absolute() ? helper : std::filesystem::path{};
+  }
+  std::error_code error;
+  const std::filesystem::path executable =
+      std::filesystem::read_symlink("/proc/self/exe", error);
+  if (error || executable.empty()) {
+    return {};
+  }
+  const std::filesystem::path directory = executable.parent_path();
+  const std::vector<std::filesystem::path> candidates = {
+      directory / "mocktail_settings",
+      directory.parent_path() / MOCKTAIL_INSTALL_LIBDIR / "mocktail" /
+          "mocktail_settings",
+      directory.parent_path() / "libexec" / "mocktail" / "mocktail_settings",
+  };
+  for (const std::filesystem::path& candidate : candidates) {
+    std::error_code status_error;
+    if (std::filesystem::is_regular_file(candidate, status_error) &&
+        access(candidate.c_str(), X_OK) == 0) {
+      return candidate;
+    }
+  }
+  return {};
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -231,6 +266,19 @@ int main(int argc, char* argv[]) {
     std::cout << mocktail::runtime::CommandLineUsage(
         command_line.options.program_name);
     return EXIT_SUCCESS;
+  }
+  if (command_line.options.mode == mocktail::runtime::CommandMode::kSettings) {
+    const mocktail::runtime::ProcessEnvironment settings_environment;
+    const std::filesystem::path helper =
+        ResolveSettingsHelper(settings_environment);
+    if (helper.empty()) {
+      std::cerr << "[FATAL] Cannot locate the Mocktail settings window\n";
+      return EXIT_FAILURE;
+    }
+    char* const arguments[] = {const_cast<char*>(helper.c_str()), nullptr};
+    execv(helper.c_str(), arguments);
+    std::cerr << "[FATAL] Cannot start the Mocktail settings window\n";
+    return EXIT_FAILURE;
   }
   std::string command_line_error;
   if (!mocktail::runtime::ApplySupportedLaunchPolicy(

--- a/src/runtime/command_line.cc
+++ b/src/runtime/command_line.cc
@@ -59,6 +59,10 @@ CommandLineParseResult ParseCommandLine(int argc, const char* const argv[]) {
       result.options.mode = CommandMode::kHelp;
       return result;
     }
+    if (argument == "--settings") {
+      result.options.mode = CommandMode::kSettings;
+      return result;
+    }
     if (argument == "--roblox-lib") {
       if (!ReadOptionValue(argc, argv, &index, argument,
                            &result.options.roblox_library_path,
@@ -256,6 +260,7 @@ std::string CommandLineUsage(const std::string& program_name) {
          "without approval; it is not activated\n"
       << "  --launch-uri <uri>       Join from a roblox: or roblox-player: "
          "website link\n"
+      << "  --settings               Open the settings window and exit\n"
       << "  --help, -h               Show this help\n\n"
       << "Auth:\n"
       << "  When no saved Roblox cookie is found, Roblox starts in guest mode "

--- a/src/runtime/discord_rpc.cc
+++ b/src/runtime/discord_rpc.cc
@@ -256,6 +256,18 @@ std::vector<std::string> DiscordSocketDirectories() {
     directories.emplace_back(std::string(runtime) +
                              "/.flatpak/com.discordapp.Discord/xdg-run");
     directories.emplace_back(std::string(runtime) + "/snap.discord");
+    // Discord-compatible clients expose the same IPC socket from their own
+    // sandbox. A native install writes straight into XDG_RUNTIME_DIR and is
+    // already covered by the entry above.
+    for (const char* application : {"com.discordapp.DiscordCanary",
+                                    "com.discordapp.DiscordPTB",
+                                    "dev.vencord.Vesktop",
+                                    "io.github.equicord.equibop",
+                                    "xyz.armcord.ArmCord"}) {
+      directories.emplace_back(std::string(runtime) + "/app/" + application);
+      directories.emplace_back(std::string(runtime) + "/.flatpak/" +
+                               application + "/xdg-run");
+    }
   }
   append(std::getenv("TMPDIR"));
   directories.emplace_back("/tmp");

--- a/src/runtime/runtime_config_writer.cc
+++ b/src/runtime/runtime_config_writer.cc
@@ -1,0 +1,486 @@
+#include "runtime/runtime_config_writer.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "runtime/runtime_paths.h"
+
+namespace mocktail {
+namespace runtime {
+namespace {
+
+constexpr std::uintmax_t kMaximumConfigBytes = 1U * 1024U * 1024U;
+constexpr std::size_t kIndentWidth = 2;
+std::atomic<std::uint64_t> g_temporary_sequence{0};
+
+struct Line {
+  std::string text;
+  // Set only for `key:` lines that are not commented out.
+  std::optional<std::string> key;
+  std::size_t indent = 0;
+  bool blank = false;
+  bool comment = false;
+  // A `# key: value` template line, used to place a missing optional key.
+  std::optional<std::string> commented_key;
+  // Indentation the key would have once the `#` and one following space are
+  // removed, so it compares directly against a block indent.
+  std::size_t commented_indent = 0;
+};
+
+std::size_t CountIndent(std::string_view text) {
+  std::size_t indent = 0;
+  while (indent < text.size() && text[indent] == ' ') {
+    ++indent;
+  }
+  return indent;
+}
+
+bool IsKeyCharacter(char character) {
+  return (character >= 'a' && character <= 'z') ||
+         (character >= 'A' && character <= 'Z') ||
+         (character >= '0' && character <= '9') || character == '_' ||
+         character == '-';
+}
+
+// Returns the key when `text` starts, at `offset`, with `key:` followed by a
+// value separator. List items and inline flow maps are deliberately not keys.
+std::optional<std::string> ParseKey(std::string_view text, std::size_t offset) {
+  std::size_t end = offset;
+  while (end < text.size() && IsKeyCharacter(text[end])) {
+    ++end;
+  }
+  if (end == offset || end >= text.size() || text[end] != ':') {
+    return std::nullopt;
+  }
+  const std::size_t after = end + 1;
+  if (after != text.size() && text[after] != ' ' && text[after] != '\t') {
+    return std::nullopt;
+  }
+  return std::string(text.substr(offset, end - offset));
+}
+
+Line ClassifyLine(std::string text) {
+  Line line;
+  line.indent = CountIndent(text);
+  const std::string_view view(text);
+  if (line.indent == view.size()) {
+    line.blank = true;
+    line.text = std::move(text);
+    return line;
+  }
+  if (view[line.indent] == '#') {
+    line.comment = true;
+    // `  # proxy_host: 127.0.0.1` and `#   type: mobile` both document a key
+    // that would sit at indent 2 once uncommented.
+    std::size_t offset = line.indent + 1;
+    std::size_t spaces = 0;
+    while (offset < view.size() && view[offset] == ' ') {
+      ++offset;
+      ++spaces;
+    }
+    if (auto key = ParseKey(view, offset)) {
+      line.commented_key = std::move(key);
+      line.commented_indent = offset - 1 - (spaces > 0 ? 1 : 0);
+    }
+    line.text = std::move(text);
+    return line;
+  }
+  line.key = ParseKey(view, line.indent);
+  line.text = std::move(text);
+  return line;
+}
+
+std::vector<Line> SplitLines(std::string_view yaml, bool* trailing_newline) {
+  std::vector<Line> lines;
+  *trailing_newline = !yaml.empty() && yaml.back() == '\n';
+  std::size_t start = 0;
+  while (start <= yaml.size()) {
+    const std::size_t end = yaml.find('\n', start);
+    if (end == std::string_view::npos) {
+      if (start < yaml.size()) {
+        lines.push_back(ClassifyLine(std::string(yaml.substr(start))));
+      }
+      break;
+    }
+    lines.push_back(ClassifyLine(std::string(yaml.substr(start, end - start))));
+    start = end + 1;
+  }
+  return lines;
+}
+
+std::string JoinLines(const std::vector<Line>& lines, bool trailing_newline) {
+  std::string output;
+  for (std::size_t index = 0; index < lines.size(); ++index) {
+    output += lines[index].text;
+    if (index + 1 < lines.size() || trailing_newline) {
+      output += '\n';
+    }
+  }
+  return output;
+}
+
+// Half-open range of the block owned by the key line at `parent`, which is the
+// whole document when `parent` is npos.
+struct Block {
+  std::size_t begin = 0;
+  // Past the block's last real key line: where a plain append belongs.
+  std::size_t end = 0;
+  // Past the block's trailing comments too. Comments document the key below
+  // them, so a section's `# key: value` templates sit after its last real key
+  // and would otherwise fall outside the block entirely.
+  std::size_t comment_end = 0;
+  std::size_t indent = 0;
+};
+
+Block DocumentBlock(const std::vector<Line>& lines) {
+  return {0, lines.size(), lines.size(), 0};
+}
+
+Block ChildBlock(const std::vector<Line>& lines, std::size_t parent) {
+  Block block;
+  block.begin = parent + 1;
+  block.indent = lines[parent].indent + kIndentWidth;
+  std::size_t end = block.begin;
+  std::size_t comment_end = lines.size();
+  for (std::size_t index = block.begin; index < lines.size(); ++index) {
+    const Line& line = lines[index];
+    if (line.blank || line.comment) {
+      continue;
+    }
+    if (line.indent <= lines[parent].indent) {
+      comment_end = index;
+      break;
+    }
+    end = index + 1;
+  }
+  block.end = end;
+  block.comment_end = comment_end;
+  // An empty block still indents one level below its parent.
+  if (block.end < block.begin) {
+    block.end = block.begin;
+  }
+  if (block.comment_end < block.end) {
+    block.comment_end = block.end;
+  }
+  return block;
+}
+
+std::optional<std::size_t> FindKey(const std::vector<Line>& lines,
+                                   const Block& block,
+                                   std::string_view key) {
+  for (std::size_t index = block.begin; index < block.end; ++index) {
+    const Line& line = lines[index];
+    if (!line.key.has_value() || line.indent != block.indent) {
+      continue;
+    }
+    if (*line.key == key) {
+      return index;
+    }
+  }
+  return std::nullopt;
+}
+
+// True when the key line carries no inline value, so the key owns a block.
+bool OpensBlock(const std::vector<Line>& lines, std::size_t index) {
+  const Line& line = lines[index];
+  const std::size_t colon = line.text.find(':', line.indent);
+  if (colon == std::string::npos) {
+    return false;
+  }
+  for (std::size_t offset = colon + 1; offset < line.text.size(); ++offset) {
+    const char character = line.text[offset];
+    if (character == ' ' || character == '\t') {
+      continue;
+    }
+    return character == '#';
+  }
+  return true;
+}
+
+// Rewrites the value while keeping indentation, the key, and any trailing
+// comment that follows the value.
+void ReplaceValue(Line* line, std::string_view value) {
+  const std::size_t colon = line->text.find(':', line->indent);
+  std::string trailing;
+  std::size_t offset = colon + 1;
+  while (offset < line->text.size() &&
+         (line->text[offset] == ' ' || line->text[offset] == '\t')) {
+    ++offset;
+  }
+  const std::size_t comment = line->text.find(" #", offset);
+  if (comment != std::string::npos) {
+    trailing = line->text.substr(comment);
+  }
+  line->text = line->text.substr(0, colon + 1) + " " + std::string(value) +
+               trailing;
+}
+
+Line MakeKeyLine(std::size_t indent, std::string_view key,
+                 std::string_view value) {
+  return ClassifyLine(std::string(indent, ' ') + std::string(key) + ": " +
+                      std::string(value));
+}
+
+// Prefers the documented slot: a `# key: ...` template at the block's indent.
+std::size_t InsertionPoint(const std::vector<Line>& lines, const Block& block,
+                           std::string_view key) {
+  for (std::size_t index = block.begin; index < block.comment_end; ++index) {
+    const Line& line = lines[index];
+    if (line.commented_key.has_value() && *line.commented_key == key &&
+        line.commented_indent == block.indent) {
+      return index + 1;
+    }
+  }
+  return block.end;
+}
+
+bool ApplyOne(std::vector<Line>* lines, const ConfigAssignment& assignment,
+              std::string* error) {
+  if (assignment.path.empty()) {
+    *error = "config assignment needs a key path";
+    return false;
+  }
+  Block block = DocumentBlock(*lines);
+  for (std::size_t depth = 0; depth + 1 < assignment.path.size(); ++depth) {
+    const std::string& segment = assignment.path[depth];
+    const std::optional<std::size_t> parent = FindKey(*lines, block, segment);
+    if (!parent.has_value()) {
+      // Append the missing section, then continue descending into it.
+      Line section = ClassifyLine(std::string(block.indent, ' ') + segment +
+                                  ":");
+      lines->insert(lines->begin() +
+                        static_cast<std::ptrdiff_t>(block.end),
+                    std::move(section));
+      block = ChildBlock(*lines, block.end);
+      continue;
+    }
+    if (!OpensBlock(*lines, *parent)) {
+      *error = "config key '" + segment + "' holds a value, not a section";
+      return false;
+    }
+    block = ChildBlock(*lines, *parent);
+  }
+
+  const std::string& leaf = assignment.path.back();
+  const std::optional<std::size_t> existing = FindKey(*lines, block, leaf);
+  if (existing.has_value()) {
+    if (OpensBlock(*lines, *existing)) {
+      *error = "config key '" + leaf +
+               "' opens a section; refusing to replace it with a value";
+      return false;
+    }
+    ReplaceValue(&(*lines)[*existing], assignment.value);
+    return true;
+  }
+  const std::size_t insertion = InsertionPoint(*lines, block, leaf);
+  lines->insert(lines->begin() + static_cast<std::ptrdiff_t>(insertion),
+                MakeKeyLine(block.indent, leaf, assignment.value));
+  return true;
+}
+
+bool WriteAll(int descriptor, std::string_view bytes) {
+  std::size_t offset = 0;
+  while (offset < bytes.size()) {
+    const ssize_t written =
+        write(descriptor, bytes.data() + offset, bytes.size() - offset);
+    if (written < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (written == 0) {
+      return false;
+    }
+    offset += static_cast<std::size_t>(written);
+  }
+  return true;
+}
+
+class ScopedFileDescriptor final {
+ public:
+  explicit ScopedFileDescriptor(int descriptor = -1)
+      : descriptor_(descriptor) {}
+  ~ScopedFileDescriptor() {
+    if (descriptor_ >= 0) {
+      close(descriptor_);
+    }
+  }
+
+  ScopedFileDescriptor(const ScopedFileDescriptor&) = delete;
+  ScopedFileDescriptor& operator=(const ScopedFileDescriptor&) = delete;
+
+  int get() const { return descriptor_; }
+
+ private:
+  int descriptor_ = -1;
+};
+
+}  // namespace
+
+std::string EncodeConfigScalar(std::string_view value) {
+  const bool needs_quotes =
+      value.empty() || value.front() == ' ' || value.back() == ' ' ||
+      value.find(": ") != std::string_view::npos ||
+      value.find(" #") != std::string_view::npos ||
+      value.find('\n') != std::string_view::npos ||
+      value.find('"') != std::string_view::npos ||
+      std::string_view("#&*!|>%@`{}[],'\"").find(value.front()) !=
+          std::string_view::npos;
+  if (!needs_quotes) {
+    return std::string(value);
+  }
+  std::string quoted = "\"";
+  for (const char character : value) {
+    if (character == '"' || character == '\\') {
+      quoted += '\\';
+    }
+    if (character == '\n') {
+      quoted += "\\n";
+      continue;
+    }
+    quoted += character;
+  }
+  quoted += '"';
+  return quoted;
+}
+
+bool ApplyConfigAssignments(std::string_view yaml,
+                            const std::vector<ConfigAssignment>& assignments,
+                            std::string* updated, std::string* error) {
+  if (updated == nullptr || error == nullptr) {
+    if (error != nullptr) {
+      *error = "config writer output is required";
+    }
+    return false;
+  }
+  bool trailing_newline = true;
+  std::vector<Line> lines = SplitLines(yaml, &trailing_newline);
+  if (lines.empty()) {
+    trailing_newline = true;
+  }
+  for (const ConfigAssignment& assignment : assignments) {
+    if (!ApplyOne(&lines, assignment, error)) {
+      return false;
+    }
+  }
+  *updated = JoinLines(lines, trailing_newline);
+  return true;
+}
+
+bool WriteConfigAssignments(const std::filesystem::path& config_file,
+                            const std::vector<ConfigAssignment>& assignments,
+                            std::string* error) {
+  if (error == nullptr) {
+    return false;
+  }
+  if (!config_file.is_absolute()) {
+    *error = "config path must be absolute";
+    return false;
+  }
+  std::error_code filesystem_error;
+  const std::filesystem::file_status status =
+      std::filesystem::symlink_status(config_file, filesystem_error);
+  if (!filesystem_error && std::filesystem::is_symlink(status)) {
+    *error = "config target is a symlink";
+    return false;
+  }
+
+  std::string original;
+  const int descriptor =
+      open(config_file.c_str(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+  if (descriptor >= 0) {
+    const ScopedFileDescriptor file(descriptor);
+    struct stat metadata{};
+    if (fstat(file.get(), &metadata) != 0 || !S_ISREG(metadata.st_mode) ||
+        metadata.st_size < 0 ||
+        static_cast<std::uintmax_t>(metadata.st_size) > kMaximumConfigBytes) {
+      *error = "config is not a bounded regular file";
+      return false;
+    }
+    original.resize(static_cast<std::size_t>(metadata.st_size));
+    std::size_t offset = 0;
+    while (offset < original.size()) {
+      const ssize_t count =
+          read(file.get(), original.data() + offset, original.size() - offset);
+      if (count < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        *error = "cannot read config";
+        return false;
+      }
+      if (count == 0) {
+        *error = "config changed while being read";
+        return false;
+      }
+      offset += static_cast<std::size_t>(count);
+    }
+  } else if (errno != ENOENT) {
+    *error = "cannot safely open config";
+    return false;
+  }
+
+  std::string updated;
+  if (!ApplyConfigAssignments(original, assignments, &updated, error)) {
+    return false;
+  }
+  if (updated == original) {
+    return true;
+  }
+
+  if (!RuntimePaths::EnsureDirectory(config_file.parent_path(),
+                                     &filesystem_error)) {
+    *error = "cannot create config directory";
+    return false;
+  }
+  const std::filesystem::path temporary =
+      config_file.parent_path() /
+      (".mocktail-config.tmp." + std::to_string(getpid()) + "." +
+       std::to_string(g_temporary_sequence.fetch_add(1)));
+  const int target =
+      open(temporary.c_str(),
+           O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
+  if (target < 0) {
+    *error = "cannot create temporary config";
+    return false;
+  }
+  bool stored = false;
+  {
+    const ScopedFileDescriptor file(target);
+    stored = fchmod(file.get(), S_IRUSR | S_IWUSR) == 0 &&
+             WriteAll(file.get(), updated) && fsync(file.get()) == 0;
+  }
+  if (!stored || rename(temporary.c_str(), config_file.c_str()) != 0) {
+    const int saved_errno = errno;
+    (void)unlink(temporary.c_str());
+    errno = saved_errno;
+    *error = "cannot atomically store config";
+    return false;
+  }
+  const int directory =
+      open(config_file.parent_path().c_str(), O_RDONLY | O_CLOEXEC | O_DIRECTORY);
+  if (directory < 0) {
+    *error = "cannot open config directory for sync";
+    return false;
+  }
+  const ScopedFileDescriptor directory_file(directory);
+  if (fsync(directory_file.get()) != 0) {
+    *error = "cannot sync config directory";
+    return false;
+  }
+  return true;
+}
+
+}  // namespace runtime
+}  // namespace mocktail

--- a/src/ui/mocktail_settings_window.cc
+++ b/src/ui/mocktail_settings_window.cc
@@ -1,0 +1,433 @@
+// Standalone settings window for the documented config.yaml.
+//
+// Settings are read through the same loader the runtime uses and written back
+// with the comment-preserving writer, so hand-written comments and untouched
+// keys survive. Every change applies instantly and takes effect at the next
+// launch, which the banner states.
+
+#include <adwaita.h>
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "runtime/environment.h"
+#include "runtime/frame_rate_policy.h"
+#include "runtime/game_mode.h"
+#include "runtime/performance_policy.h"
+#include "runtime/runtime_config.h"
+#include "runtime/runtime_config_file.h"
+#include "runtime/runtime_config_writer.h"
+#include "runtime/runtime_paths.h"
+
+namespace {
+
+namespace mr = mocktail::runtime;
+
+struct Choice {
+  const char* value;
+  const char* label;
+};
+
+constexpr Choice kBackends[] = {
+    {"direct-vulkan", "Vulkan (recommended)"},
+    {"opengl", "OpenGL"},
+    {"angle-vulkan", "ANGLE over Vulkan"},
+    {"system", "System default"},
+};
+
+constexpr Choice kFrameRates[] = {
+    {"display", "Match display"}, {"30", "30 FPS"},   {"60", "60 FPS"},
+    {"120", "120 FPS"},           {"144", "144 FPS"}, {"240", "240 FPS"},
+    {"unlimited", "Unlimited"},
+};
+
+constexpr Choice kVsync[] = {
+    {"auto", "Automatic"},
+    {"on", "On"},
+    {"off", "Off"},
+};
+
+constexpr Choice kThemes[] = {
+    {"system", "Follow system"},
+    {"light", "Light"},
+    {"dark", "Dark"},
+};
+
+constexpr Choice kPhysicsModes[] = {
+    {"throughput", "Throughput (use every core)"},
+    {"latency", "Latency (Roblox pool sizes)"},
+    {"auto", "Automatic"},
+};
+
+constexpr Choice kGameModes[] = {
+    {"auto", "When available"},
+    {"on", "Always"},
+    {"off", "Never"},
+};
+
+constexpr Choice kDevices[] = {
+    {"pc-windows-11", "PC (Windows 11)"},
+    {"mobile-pixel-7", "Mobile (Pixel 7)"},
+    {"console-ps5", "Console (PS5)"},
+};
+
+struct Settings {
+  AdwApplicationWindow* window = nullptr;
+  AdwToastOverlay* toasts = nullptr;
+  std::string config_path;
+  // Set while widgets are populated, so programmatic updates do not write.
+  bool loading = true;
+};
+
+void ShowToast(Settings* settings, const char* text) {
+  adw_toast_overlay_add_toast(settings->toasts, adw_toast_new(text));
+}
+
+void Persist(Settings* settings, std::vector<std::string> path,
+             const std::string& value) {
+  if (settings->loading) {
+    return;
+  }
+  mr::ConfigAssignment assignment;
+  assignment.path = std::move(path);
+  assignment.value = value;
+  std::string error;
+  if (!mr::WriteConfigAssignments(settings->config_path, {assignment},
+                                  &error)) {
+    const std::string message = "Could not save: " + error;
+    ShowToast(settings, message.c_str());
+    return;
+  }
+  ShowToast(settings, "Saved. Restart Mocktail to apply.");
+}
+
+// Each row owns the config path it writes to, freed with the widget.
+struct RowTarget {
+  Settings* settings;
+  std::vector<std::string> path;
+  const Choice* choices;
+  unsigned choice_count;
+};
+
+void DestroyRowTarget(gpointer data, GClosure*) {
+  delete static_cast<RowTarget*>(data);
+}
+
+RowTarget* MakeTarget(Settings* settings, std::vector<std::string> path,
+                      const Choice* choices = nullptr,
+                      unsigned choice_count = 0) {
+  auto* target = new RowTarget{settings, std::move(path), choices,
+                               choice_count};
+  return target;
+}
+
+void OnComboChanged(AdwComboRow* row, GParamSpec*, gpointer data) {
+  auto* target = static_cast<RowTarget*>(data);
+  const guint selected = adw_combo_row_get_selected(row);
+  if (selected >= target->choice_count) {
+    return;
+  }
+  Persist(target->settings, target->path,
+          mr::EncodeConfigScalar(target->choices[selected].value));
+}
+
+void OnSwitchChanged(AdwSwitchRow* row, GParamSpec*, gpointer data) {
+  auto* target = static_cast<RowTarget*>(data);
+  Persist(target->settings, target->path,
+          adw_switch_row_get_active(row) ? "true" : "false");
+}
+
+void OnSpinChanged(AdwSpinRow* row, GParamSpec*, gpointer data) {
+  auto* target = static_cast<RowTarget*>(data);
+  Persist(target->settings, target->path,
+          std::to_string(static_cast<long>(adw_spin_row_get_value(row))));
+}
+
+void OnEntryApplied(AdwEntryRow* row, gpointer data) {
+  auto* target = static_cast<RowTarget*>(data);
+  const char* text = gtk_editable_get_text(GTK_EDITABLE(row));
+  Persist(target->settings, target->path,
+          mr::EncodeConfigScalar(text != nullptr ? text : ""));
+}
+
+GtkStringList* BuildLabels(const Choice* choices, unsigned count) {
+  GtkStringList* list = gtk_string_list_new(nullptr);
+  for (unsigned index = 0; index < count; ++index) {
+    gtk_string_list_append(list, choices[index].label);
+  }
+  return list;
+}
+
+guint IndexOf(const Choice* choices, unsigned count, const std::string& value) {
+  for (unsigned index = 0; index < count; ++index) {
+    if (value == choices[index].value) {
+      return index;
+    }
+  }
+  return 0;
+}
+
+AdwComboRow* AddCombo(AdwPreferencesGroup* group, Settings* settings,
+                      const char* title, const char* subtitle,
+                      const Choice* choices, unsigned count,
+                      const std::string& current,
+                      std::vector<std::string> path) {
+  auto* row = ADW_COMBO_ROW(adw_combo_row_new());
+  adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+  if (subtitle != nullptr) {
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(row), subtitle);
+  }
+  adw_combo_row_set_model(row, G_LIST_MODEL(BuildLabels(choices, count)));
+  adw_combo_row_set_selected(row, IndexOf(choices, count, current));
+  g_signal_connect_data(row, "notify::selected",
+                        G_CALLBACK(OnComboChanged),
+                        MakeTarget(settings, std::move(path), choices, count),
+                        DestroyRowTarget, G_CONNECT_DEFAULT);
+  adw_preferences_group_add(group, GTK_WIDGET(row));
+  return row;
+}
+
+void AddSwitch(AdwPreferencesGroup* group, Settings* settings,
+               const char* title, const char* subtitle, bool active,
+               std::vector<std::string> path) {
+  auto* row = ADW_SWITCH_ROW(adw_switch_row_new());
+  adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+  if (subtitle != nullptr) {
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(row), subtitle);
+  }
+  adw_switch_row_set_active(row, active ? TRUE : FALSE);
+  g_signal_connect_data(row, "notify::active", G_CALLBACK(OnSwitchChanged),
+                        MakeTarget(settings, std::move(path)),
+                        DestroyRowTarget, G_CONNECT_DEFAULT);
+  adw_preferences_group_add(group, GTK_WIDGET(row));
+}
+
+void AddSpin(AdwPreferencesGroup* group, Settings* settings, const char* title,
+             const char* subtitle, double value, double minimum, double maximum,
+             double step, std::vector<std::string> path) {
+  auto* row = ADW_SPIN_ROW(adw_spin_row_new_with_range(minimum, maximum, step));
+  adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+  if (subtitle != nullptr) {
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(row), subtitle);
+  }
+  adw_spin_row_set_value(row, value);
+  g_signal_connect_data(row, "notify::value", G_CALLBACK(OnSpinChanged),
+                        MakeTarget(settings, std::move(path)),
+                        DestroyRowTarget, G_CONNECT_DEFAULT);
+  adw_preferences_group_add(group, GTK_WIDGET(row));
+}
+
+void AddEntry(AdwPreferencesGroup* group, Settings* settings, const char* title,
+              const char* subtitle, const std::string& value,
+              std::vector<std::string> path) {
+  auto* row = ADW_ENTRY_ROW(adw_entry_row_new());
+  adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+  adw_entry_row_set_show_apply_button(row, TRUE);
+  gtk_editable_set_text(GTK_EDITABLE(row), value.c_str());
+  if (subtitle != nullptr) {
+    gtk_widget_set_tooltip_text(GTK_WIDGET(row), subtitle);
+  }
+  g_signal_connect_data(row, "apply", G_CALLBACK(OnEntryApplied),
+                        MakeTarget(settings, std::move(path)),
+                        DestroyRowTarget, G_CONNECT_DEFAULT);
+  adw_preferences_group_add(group, GTK_WIDGET(row));
+}
+
+AdwPreferencesGroup* AddGroup(AdwPreferencesPage* page, const char* title,
+                              const char* description) {
+  auto* group = ADW_PREFERENCES_GROUP(adw_preferences_group_new());
+  adw_preferences_group_set_title(group, title);
+  if (description != nullptr) {
+    adw_preferences_group_set_description(group, description);
+  }
+  adw_preferences_page_add(page, group);
+  return group;
+}
+
+std::string FrameRateValue(const mr::RuntimeConfig& config) {
+  const mr::FrameRatePolicy& policy = config.frame_rate();
+  switch (policy.mode) {
+    case mr::FrameRateLimitMode::kUnlimited:
+      return "unlimited";
+    case mr::FrameRateLimitMode::kFixed:
+      return std::to_string(policy.fixed_fps);
+    case mr::FrameRateLimitMode::kDisplay:
+    case mr::FrameRateLimitMode::kInvalid:
+      break;
+  }
+  return "display";
+}
+
+void BuildUi(Settings* settings, const mr::RuntimeConfig& config,
+             bool device_is_mapping) {
+  auto* page = ADW_PREFERENCES_PAGE(adw_preferences_page_new());
+
+  AdwPreferencesGroup* graphics =
+      AddGroup(page, "Graphics", "Applied the next time Mocktail starts.");
+  AddCombo(graphics, settings, "Renderer",
+           "Use OpenGL only when Vulkan is unavailable.", kBackends,
+           G_N_ELEMENTS(kBackends), config.graphics_backend_name(),
+           {"graphics", "backend"});
+  AddCombo(graphics, settings, "Frame rate limit", nullptr, kFrameRates,
+           G_N_ELEMENTS(kFrameRates), FrameRateValue(config),
+           {"graphics", "frame_rate_limit"});
+  AddCombo(graphics, settings, "V-Sync", nullptr, kVsync,
+           G_N_ELEMENTS(kVsync), config.vsync_mode(), {"graphics", "vsync"});
+
+  AdwPreferencesGroup* appearance = AddGroup(page, "Appearance", nullptr);
+  AddCombo(appearance, settings, "Theme", nullptr, kThemes,
+           G_N_ELEMENTS(kThemes), config.theme_mode(),
+           {"appearance", "theme"});
+
+  AdwPreferencesGroup* device = AddGroup(
+      page, "Device profile",
+      "Reported to Roblox. The PC profile enables the desktop layout.");
+  AdwComboRow* device_row =
+      AddCombo(device, settings, "Preset", nullptr, kDevices,
+               G_N_ELEMENTS(kDevices), config.device_profile().name,
+               {"device"});
+  if (device_is_mapping) {
+    // A hand-written mapping cannot be replaced by a preset without losing it.
+    gtk_widget_set_sensitive(GTK_WIDGET(device_row), FALSE);
+    adw_action_row_set_subtitle(
+        ADW_ACTION_ROW(device_row),
+        "Managed by a custom device block in config.yaml.");
+  }
+
+  AdwPreferencesGroup* performance = AddGroup(page, "Performance", nullptr);
+  AddSwitch(performance, settings, "Multithreaded rendering",
+            "Size Roblox queues from every physical core.",
+            config.performance().multithreaded_rendering,
+            {"performance", "multithreaded_rendering"});
+  AddCombo(performance, settings, "Physics workers", nullptr, kPhysicsModes,
+           G_N_ELEMENTS(kPhysicsModes),
+           std::string(mr::PhysicsWorkerModeName(
+               config.performance().physics_worker_mode)),
+           {"performance", "physics_worker_mode"});
+  AddCombo(performance, settings, "Feral GameMode", nullptr, kGameModes,
+           G_N_ELEMENTS(kGameModes),
+           std::string(mr::GameModePolicyName(config.performance().game_mode)),
+           {"performance", "gamemode"});
+  AddSpin(performance, settings, "Memory limit",
+          "MiB. 0 disables the cap.",
+          static_cast<double>(config.performance().memory_limit_mb), 0, 131072,
+          512, {"performance", "memory_limit_mb"});
+
+  AdwPreferencesGroup* window = AddGroup(page, "Window", nullptr);
+  AddSpin(window, settings, "Width", nullptr, config.window().width, 640, 15360,
+          16, {"window", "width"});
+  AddSpin(window, settings, "Height", nullptr, config.window().height, 480,
+          8640, 16, {"window", "height"});
+  AddEntry(window, settings, "Title", nullptr, config.window().title,
+           {"window", "title"});
+
+  AdwPreferencesGroup* audio = AddGroup(
+      page, "Audio",
+      "Use `default` to follow the host, or an exact device name from the "
+      "startup log.");
+  AddEntry(audio, settings, "Output device", nullptr,
+           config.audio_output_device(), {"audio", "output_device"});
+  AddEntry(audio, settings, "Input device",
+           "Use `disabled` to deny Roblox the microphone.",
+           config.audio_input_device(), {"audio", "input_device"});
+
+  AdwPreferencesGroup* integrations = AddGroup(page, "Integrations", nullptr);
+  AddSwitch(integrations, settings, "Discord Rich Presence",
+            "Never signs in to Discord and never reads an account token.",
+            config.discord_rpc().enabled,
+            {"integrations", "discord_rpc", "enabled"});
+  AddSwitch(integrations, settings, "System proxy",
+            "Follow the host HTTP or SOCKS5 proxy.", config.use_system_proxy(),
+            {"network", "use_system_proxy"});
+
+  auto* banner = ADW_BANNER(adw_banner_new(
+      "Changes are saved to config.yaml and apply the next time Mocktail "
+      "starts."));
+  adw_banner_set_revealed(banner, TRUE);
+
+  auto* header = ADW_HEADER_BAR(adw_header_bar_new());
+  auto* content = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  gtk_box_append(content, GTK_WIDGET(header));
+  gtk_box_append(content, GTK_WIDGET(banner));
+  gtk_box_append(content, GTK_WIDGET(page));
+  gtk_widget_set_vexpand(GTK_WIDGET(page), TRUE);
+
+  settings->toasts = ADW_TOAST_OVERLAY(adw_toast_overlay_new());
+  adw_toast_overlay_set_child(settings->toasts, GTK_WIDGET(content));
+  adw_application_window_set_content(settings->window,
+                                     GTK_WIDGET(settings->toasts));
+}
+
+// True when `device:` opens a mapping rather than holding a preset name.
+bool DeviceIsMapping(const std::string& path) {
+  std::string yaml;
+  {
+    FILE* file = std::fopen(path.c_str(), "re");
+    if (file == nullptr) {
+      return false;
+    }
+    char buffer[4096];
+    std::size_t count = 0;
+    while ((count = std::fread(buffer, 1, sizeof(buffer), file)) > 0) {
+      yaml.append(buffer, count);
+    }
+    std::fclose(file);
+  }
+  std::size_t offset = 0;
+  while (offset < yaml.size()) {
+    const std::size_t end = yaml.find('\n', offset);
+    const std::string line =
+        yaml.substr(offset, end == std::string::npos ? std::string::npos
+                                                     : end - offset);
+    if (line.rfind("device:", 0) == 0) {
+      return line.find_first_not_of(" \t", 7) == std::string::npos;
+    }
+    if (end == std::string::npos) {
+      break;
+    }
+    offset = end + 1;
+  }
+  return false;
+}
+
+void OnActivate(AdwApplication* application, gpointer data) {
+  auto* settings = static_cast<Settings*>(data);
+  settings->loading = true;
+
+  const mr::ProcessEnvironment environment;
+  const mr::RuntimePaths paths = mr::RuntimePaths::FromEnvironment(environment);
+  settings->config_path = paths.config_file().string();
+  const mr::RuntimeConfigLoadResult loaded =
+      mr::LoadRuntimeConfig(environment, paths.config_file());
+
+  settings->window = ADW_APPLICATION_WINDOW(
+      adw_application_window_new(GTK_APPLICATION(application)));
+  gtk_window_set_title(GTK_WINDOW(settings->window), "Mocktail Settings");
+  gtk_window_set_default_size(GTK_WINDOW(settings->window), 640, 760);
+
+  if (!loaded) {
+    auto* status = ADW_STATUS_PAGE(adw_status_page_new());
+    adw_status_page_set_icon_name(status, "dialog-error-symbolic");
+    adw_status_page_set_title(status, "Cannot read the configuration");
+    adw_status_page_set_description(status, loaded.error.c_str());
+    adw_application_window_set_content(settings->window, GTK_WIDGET(status));
+  } else {
+    BuildUi(settings, loaded.config, DeviceIsMapping(settings->config_path));
+  }
+
+  settings->loading = false;
+  gtk_window_present(GTK_WINDOW(settings->window));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  Settings settings;
+  AdwApplication* application = adw_application_new(
+      "space.bigrat.mocktail.Settings", G_APPLICATION_DEFAULT_FLAGS);
+  g_signal_connect(application, "activate", G_CALLBACK(OnActivate), &settings);
+  const int status = g_application_run(G_APPLICATION(application), argc, argv);
+  g_object_unref(application);
+  return status;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,15 @@ target_link_libraries(performance_policy_test PRIVATE
   GTest::gtest_main
 )
 
+add_executable(runtime_config_writer_test runtime_config_writer_test.cc)
+target_link_libraries(runtime_config_writer_test PRIVATE
+  Mocktail::Runtime
+  GTest::gtest_main
+)
+target_compile_definitions(runtime_config_writer_test PRIVATE
+  MOCKTAIL_EXAMPLE_CONFIG_PATH="${PROJECT_SOURCE_DIR}/config/mocktail.example.yaml"
+)
+
 add_executable(http_client_policy_test http_client_policy_test.cc)
 target_link_libraries(http_client_policy_test PRIVATE
   Mocktail::Runtime
@@ -810,6 +819,7 @@ gtest_discover_tests(session_log_test)
 gtest_discover_tests(failure_dialog_test)
 gtest_discover_tests(frame_rate_policy_test)
 gtest_discover_tests(performance_policy_test)
+gtest_discover_tests(runtime_config_writer_test)
 gtest_discover_tests(http_client_policy_test)
 gtest_discover_tests(http_client_spin_guard_test)
 gtest_discover_tests(crash_report_policy_test)

--- a/tests/command_line_test.cc
+++ b/tests/command_line_test.cc
@@ -262,13 +262,29 @@ TEST(CommandLineTest, HelpIsATypedAuxiliaryMode) {
   EXPECT_EQ(help_result.options.mode, CommandMode::kHelp);
 }
 
+TEST(CommandLineTest, SettingsIsATypedAuxiliaryMode) {
+  const std::array<const char*, 2> settings = {"mocktail", "--settings"};
+  const CommandLineParseResult result =
+      ParseCommandLine(settings.size(), settings.data());
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result.options.mode, CommandMode::kSettings);
+
+  // The mode wins immediately, so a later launch argument cannot start Roblox.
+  const std::array<const char*, 3> with_uri = {"mocktail", "--settings",
+                                               "roblox://placeId=1"};
+  const CommandLineParseResult guarded =
+      ParseCommandLine(with_uri.size(), with_uri.data());
+  ASSERT_TRUE(guarded);
+  EXPECT_EQ(guarded.options.mode, CommandMode::kSettings);
+}
+
 TEST(CommandLineTest, UsageContainsEverySupportedOption) {
   const std::string usage = CommandLineUsage("mocktail-test");
   EXPECT_NE(usage.find("mocktail-test"), std::string::npos);
   for (const char* option :
        {"--roblox-lib", "--headless", "--windowed", "--graphics",
         "--allow-unverified-build", "--force-run-latest", "--launch-uri",
-        "--help"}) {
+        "--settings", "--help"}) {
     EXPECT_NE(usage.find(option), std::string::npos) << option;
   }
   EXPECT_EQ(usage.find("--login"), std::string::npos);

--- a/tests/runtime_config_writer_test.cc
+++ b/tests/runtime_config_writer_test.cc
@@ -1,0 +1,373 @@
+#include "runtime/runtime_config_writer.h"
+
+#include "runtime/runtime_config_file.h"
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace mocktail {
+namespace runtime {
+namespace {
+
+class TemporaryDirectory final {
+ public:
+  TemporaryDirectory() {
+    char pattern[] = "/tmp/mocktail_config_writer_XXXXXX";
+    char* created = mkdtemp(pattern);
+    if (created != nullptr) {
+      path_ = created;
+    }
+  }
+  ~TemporaryDirectory() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  const std::filesystem::path& path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+std::string Apply(std::string_view yaml,
+                  const std::vector<ConfigAssignment>& assignments) {
+  std::string updated;
+  std::string error;
+  EXPECT_TRUE(ApplyConfigAssignments(yaml, assignments, &updated, &error))
+      << error;
+  return updated;
+}
+
+constexpr char kDocumentedConfig[] = R"(# Mocktail configuration.
+# The file is created once with mode 0600. Mocktail never replaces your edits.
+
+# Integer: configuration schema version. Only version 1 is supported.
+version: 1
+
+# One-line device preset. Short aliases pc, mobile, and console are accepted.
+device: pc-windows-11
+
+graphics:
+  # String (default: direct-vulkan): graphics backend.
+  backend: direct-vulkan
+  # String or integer (default: display): requested frame-rate policy.
+  frame_rate_limit: display
+  # String (default: auto): presentation synchronization: auto, on, or off.
+  vsync: auto
+
+network:
+  # Boolean (default: false): follow the host HTTP/SOCKS5 proxy.
+  use_system_proxy: false
+  # String (optional, default: disabled): proxy host name or IP address.
+  # proxy_host: 127.0.0.1
+  # Integer (optional, default: disabled): proxy TCP port from 1 to 65535.
+  # proxy_port: 8080
+)";
+
+TEST(RuntimeConfigWriterTest, KeepsEveryCommentAndUntouchedValue) {
+  const std::string updated =
+      Apply(kDocumentedConfig, {{{"graphics", "backend"}, "opengl"}});
+
+  EXPECT_NE(updated.find("# Mocktail configuration."), std::string::npos);
+  EXPECT_NE(updated.find("# String (default: direct-vulkan): graphics backend."),
+            std::string::npos);
+  EXPECT_NE(updated.find("  backend: opengl"), std::string::npos);
+  EXPECT_EQ(updated.find("direct-vulkan\n"), std::string::npos);
+  EXPECT_NE(updated.find("  frame_rate_limit: display"), std::string::npos);
+  EXPECT_NE(updated.find("version: 1"), std::string::npos);
+  // Same number of lines: an existing key is edited, never re-inserted.
+  const auto count = [](const std::string& text) {
+    return std::count(text.begin(), text.end(), '\n');
+  };
+  EXPECT_EQ(count(updated), count(kDocumentedConfig));
+}
+
+TEST(RuntimeConfigWriterTest, EditsSeveralKeysAcrossSections) {
+  const std::string updated = Apply(kDocumentedConfig,
+                                    {
+                                        {{"graphics", "vsync"}, "off"},
+                                        {{"graphics", "frame_rate_limit"}, "144"},
+                                        {{"network", "use_system_proxy"}, "true"},
+                                        {{"device"}, "mobile-pixel-7"},
+                                    });
+
+  EXPECT_NE(updated.find("  vsync: off"), std::string::npos);
+  EXPECT_NE(updated.find("  frame_rate_limit: 144"), std::string::npos);
+  EXPECT_NE(updated.find("  use_system_proxy: true"), std::string::npos);
+  EXPECT_NE(updated.find("device: mobile-pixel-7"), std::string::npos);
+}
+
+TEST(RuntimeConfigWriterTest, InsertsAMissingKeyAtItsDocumentedSlot) {
+  const std::string updated =
+      Apply(kDocumentedConfig, {{{"network", "proxy_host"}, "10.0.0.2"}});
+
+  const std::size_t documentation =
+      updated.find("  # String (optional, default: disabled): proxy host");
+  const std::size_t inserted = updated.find("  proxy_host: 10.0.0.2");
+  const std::size_t template_line = updated.find("  # proxy_host: 127.0.0.1");
+  ASSERT_NE(inserted, std::string::npos);
+  ASSERT_NE(template_line, std::string::npos);
+  // The value lands right after the commented template, under its own comment.
+  EXPECT_LT(documentation, template_line);
+  EXPECT_LT(template_line, inserted);
+  EXPECT_LT(inserted, updated.find("  # Integer (optional, default: disabled)"));
+}
+
+TEST(RuntimeConfigWriterTest, AppendsAMissingSection) {
+  const std::string updated =
+      Apply(kDocumentedConfig, {{{"audio", "output_device"}, "default"}});
+
+  EXPECT_NE(updated.find("audio:"), std::string::npos);
+  EXPECT_NE(updated.find("  output_device: default"), std::string::npos);
+  EXPECT_NE(updated.find("version: 1"), std::string::npos);
+  EXPECT_NE(updated.find("  use_system_proxy: false"), std::string::npos);
+}
+
+TEST(RuntimeConfigWriterTest, RefusesToFlattenAMappingDeviceProfile) {
+  constexpr char kMappingDevice[] = R"(version: 1
+device:
+  type: mobile
+  name: Google Pixel 9 Pro
+  touch: true
+)";
+  std::string updated;
+  std::string error;
+  EXPECT_FALSE(ApplyConfigAssignments(kMappingDevice,
+                                      {{{"device"}, "pc-windows-11"}}, &updated,
+                                      &error));
+  EXPECT_NE(error.find("opens a section"), std::string::npos);
+  // A nested assignment into the same mapping is still allowed.
+  EXPECT_NE(Apply(kMappingDevice, {{{"device", "touch"}, "false"}})
+                .find("  touch: false"),
+            std::string::npos);
+}
+
+TEST(RuntimeConfigWriterTest, RefusesToDescendIntoAScalar) {
+  std::string updated;
+  std::string error;
+  EXPECT_FALSE(ApplyConfigAssignments(kDocumentedConfig,
+                                      {{{"version", "minor"}, "2"}}, &updated,
+                                      &error));
+  EXPECT_NE(error.find("holds a value"), std::string::npos);
+  EXPECT_FALSE(ApplyConfigAssignments(kDocumentedConfig, {{{}, "x"}}, &updated,
+                                      &error));
+}
+
+TEST(RuntimeConfigWriterTest, PreservesATrailingComment) {
+  const std::string updated =
+      Apply("graphics:\n  vsync: auto # keep me\n", {{{"graphics", "vsync"}, "on"}});
+  EXPECT_EQ(updated, "graphics:\n  vsync: on # keep me\n");
+}
+
+TEST(RuntimeConfigWriterTest, QuotesOnlyWhatWouldNotRoundTrip) {
+  EXPECT_EQ(EncodeConfigScalar("Roblox"), "Roblox");
+  EXPECT_EQ(EncodeConfigScalar("direct-vulkan"), "direct-vulkan");
+  EXPECT_EQ(EncodeConfigScalar("144"), "144");
+  EXPECT_EQ(EncodeConfigScalar("My Device 2"), "My Device 2");
+  EXPECT_EQ(EncodeConfigScalar(""), "\"\"");
+  EXPECT_EQ(EncodeConfigScalar(" padded "), "\" padded \"");
+  EXPECT_EQ(EncodeConfigScalar("a: b"), "\"a: b\"");
+  EXPECT_EQ(EncodeConfigScalar("name #1"), "\"name #1\"");
+  EXPECT_EQ(EncodeConfigScalar("{place_name}"), "\"{place_name}\"");
+  EXPECT_EQ(EncodeConfigScalar("say \"hi\""), "\"say \\\"hi\\\"\"");
+}
+
+TEST(RuntimeConfigWriterTest, EncodedScalarSurvivesTheWriter) {
+  const std::string updated = Apply(
+      "window:\n  title: Roblox\n",
+      {{{"window", "title"}, EncodeConfigScalar("My # Window")}});
+  EXPECT_EQ(updated, "window:\n  title: \"My # Window\"\n");
+}
+
+TEST(RuntimeConfigWriterTest, HandlesAnEmptyOrNewlineFreeDocument) {
+  EXPECT_EQ(Apply("", {{{"graphics", "vsync"}, "on"}}),
+            "graphics:\n  vsync: on\n");
+  // No trailing newline in, none added.
+  EXPECT_EQ(Apply("graphics:\n  vsync: auto", {{{"graphics", "vsync"}, "on"}}),
+            "graphics:\n  vsync: on");
+}
+
+TEST(RuntimeConfigWriterTest, WritesAtomicallyWithOwnerOnlyMode) {
+  TemporaryDirectory temporary;
+  ASSERT_FALSE(temporary.path().empty());
+  const std::filesystem::path config = temporary.path() / "config.yaml";
+  {
+    std::ofstream output(config);
+    output << kDocumentedConfig;
+  }
+  ASSERT_EQ(chmod(config.c_str(), 0600), 0);
+
+  std::string error;
+  ASSERT_TRUE(WriteConfigAssignments(
+      config, {{{"graphics", "backend"}, "opengl"}}, &error))
+      << error;
+
+  std::ifstream input(config);
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  EXPECT_NE(buffer.str().find("  backend: opengl"), std::string::npos);
+  EXPECT_NE(buffer.str().find("# Mocktail configuration."), std::string::npos);
+
+  struct stat metadata{};
+  ASSERT_EQ(stat(config.c_str(), &metadata), 0);
+  EXPECT_EQ(metadata.st_mode & 0777, 0600u);
+  // No temporary file is left behind.
+  for (const auto& entry : std::filesystem::directory_iterator(temporary.path())) {
+    EXPECT_EQ(entry.path().filename().string().find(".mocktail-config.tmp."),
+              std::string::npos);
+  }
+}
+
+TEST(RuntimeConfigWriterTest, CreatesTheFileWhenItIsMissing) {
+  TemporaryDirectory temporary;
+  ASSERT_FALSE(temporary.path().empty());
+  const std::filesystem::path config = temporary.path() / "new/config.yaml";
+  std::string error;
+  ASSERT_TRUE(WriteConfigAssignments(config, {{{"graphics", "vsync"}, "off"}},
+                                     &error))
+      << error;
+  std::ifstream input(config);
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  EXPECT_EQ(buffer.str(), "graphics:\n  vsync: off\n");
+}
+
+TEST(RuntimeConfigWriterTest, RejectsSymlinkedAndRelativeTargets) {
+  TemporaryDirectory temporary;
+  ASSERT_FALSE(temporary.path().empty());
+  const std::filesystem::path real = temporary.path() / "real.yaml";
+  {
+    std::ofstream output(real);
+    output << "graphics:\n  vsync: auto\n";
+  }
+  const std::filesystem::path link = temporary.path() / "link.yaml";
+  std::error_code code;
+  std::filesystem::create_symlink(real, link, code);
+  ASSERT_FALSE(code);
+
+  std::string error;
+  EXPECT_FALSE(
+      WriteConfigAssignments(link, {{{"graphics", "vsync"}, "on"}}, &error));
+  EXPECT_NE(error.find("symlink"), std::string::npos);
+  EXPECT_FALSE(WriteConfigAssignments("relative.yaml",
+                                      {{{"graphics", "vsync"}, "on"}}, &error));
+}
+
+TEST(RuntimeConfigWriterTest, LeavesTheFileAloneWhenNothingChanges) {
+  TemporaryDirectory temporary;
+  ASSERT_FALSE(temporary.path().empty());
+  const std::filesystem::path config = temporary.path() / "config.yaml";
+  {
+    std::ofstream output(config);
+    output << kDocumentedConfig;
+  }
+  const auto before = std::filesystem::last_write_time(config);
+  std::string error;
+  ASSERT_TRUE(WriteConfigAssignments(
+      config, {{{"graphics", "backend"}, "direct-vulkan"}}, &error))
+      << error;
+  EXPECT_EQ(std::filesystem::last_write_time(config), before);
+}
+
+#ifdef MOCKTAIL_EXAMPLE_CONFIG_PATH
+class NoEnvironment final : public Environment {
+ public:
+  std::optional<std::string> Get(std::string_view) const override {
+    return std::nullopt;
+  }
+};
+
+std::size_t CountCommentLines(const std::string& text) {
+  std::size_t count = 0;
+  std::istringstream stream(text);
+  std::string line;
+  while (std::getline(stream, line)) {
+    const std::size_t indent = line.find_first_not_of(' ');
+    if (indent != std::string::npos && line[indent] == '#') {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// The shipped config is the writer's real contract: 80+ comment lines that a
+// YAML round-trip would delete, plus every documented key.
+TEST(RuntimeConfigWriterTest, RewritesTheShippedExampleConfigLosslessly) {
+  std::ifstream input(MOCKTAIL_EXAMPLE_CONFIG_PATH);
+  ASSERT_TRUE(input.good()) << MOCKTAIL_EXAMPLE_CONFIG_PATH;
+  std::stringstream buffer;
+  buffer << input.rdbuf();
+  const std::string original = buffer.str();
+  ASSERT_FALSE(original.empty());
+
+  const std::string updated =
+      Apply(original, {
+                          {{"device"}, "mobile-pixel-7"},
+                          {{"runtime", "headless"}, "true"},
+                          {{"appearance", "theme"}, "dark"},
+                          {{"graphics", "backend"}, "opengl"},
+                          {{"graphics", "frame_rate_limit"}, "144"},
+                          {{"graphics", "vsync"}, "off"},
+                          {{"performance", "multithreaded_rendering"}, "true"},
+                          {{"performance", "physics_worker_mode"}, "latency"},
+                          {{"performance", "memory_limit_mb"}, "6144"},
+                          {{"performance", "gamemode"}, "on"},
+                          {{"audio", "input_device"}, "disabled"},
+                          {{"window", "width"}, "1920"},
+                          {{"window", "height"}, "1080"},
+                          {{"window", "title"}, EncodeConfigScalar("My # Roblox")},
+                          {{"network", "use_system_proxy"}, "true"},
+                          {{"integrations", "discord_rpc", "enabled"}, "true"},
+                          {{"integrations", "discord_rpc", "join",
+                            "public_servers_only"},
+                           "false"},
+                          {{"updates", "automatic"}, "false"},
+                      });
+
+  EXPECT_EQ(CountCommentLines(updated), CountCommentLines(original));
+  EXPECT_EQ(std::count(updated.begin(), updated.end(), '\n'),
+            std::count(original.begin(), original.end(), '\n'));
+
+  // The result must still parse, and every value must survive the trip.
+  TemporaryDirectory temporary;
+  ASSERT_FALSE(temporary.path().empty());
+  const std::filesystem::path config = temporary.path() / "config.yaml";
+  {
+    std::ofstream output(config);
+    output << updated;
+  }
+  const NoEnvironment environment;
+  const RuntimeConfigLoadResult loaded = LoadRuntimeConfig(environment, config);
+  ASSERT_TRUE(loaded) << loaded.error;
+  EXPECT_TRUE(loaded.file_loaded);
+  EXPECT_EQ(loaded.config.device_profile().name, "mobile-pixel-7");
+  EXPECT_EQ(loaded.config.device_profile().device_class, DeviceClass::kMobile);
+  EXPECT_TRUE(loaded.config.headless());
+  EXPECT_EQ(loaded.config.theme_mode(), "dark");
+  EXPECT_EQ(loaded.config.graphics_backend_name(), "opengl");
+  EXPECT_EQ(loaded.config.vsync_mode(), "off");
+  EXPECT_TRUE(loaded.config.performance().multithreaded_rendering);
+  EXPECT_EQ(loaded.config.performance().physics_worker_mode,
+            PhysicsWorkerMode::kLatency);
+  EXPECT_EQ(loaded.config.performance().memory_limit_mb, 6144u);
+  EXPECT_EQ(loaded.config.window().width, 1920);
+  EXPECT_EQ(loaded.config.window().height, 1080);
+  EXPECT_EQ(loaded.config.window().title, "My # Roblox");
+  EXPECT_FALSE(loaded.config.microphone_enabled());
+  EXPECT_TRUE(loaded.config.use_system_proxy());
+  EXPECT_TRUE(loaded.config.discord_rpc().enabled);
+  EXPECT_FALSE(loaded.config.discord_rpc().public_servers_only);
+}
+#endif
+
+}  // namespace
+}  // namespace runtime
+}  // namespace mocktail


### PR DESCRIPTION
## What this adds

A settings window for `config.yaml`, so Mocktail can be configured without
editing YAML by hand.

Open it with `mocktail --settings`, or right-click the launcher icon → Settings.

It covers graphics (renderer, FPS limit, V-Sync), appearance, device profile,
performance, window size and title, audio devices, and integrations. Values are
read through the same loader the runtime uses, written on change, and applied at
the next launch.

## Three commits

**1. Config writer.** `runtime_config_file` could only read, so nothing could
write the config. The new writer edits it line by line: all 86 comment lines,
the key order, and every untouched value survive. Atomic, stays mode 0600.

**2. The window**, the `--settings` mode, and a desktop action. This also fixes
`register_url_handler.sh`, which rewrote *every* `Exec=` line in the template
and would have pointed the new Settings action at the game.

**3. Discord.** Rich Presence only found Discord's own IPC socket. It now also
looks in the sandbox paths of Vesktop, Equibop, ArmCord, Canary and PTB. Still
off by default.

## One thing worth flagging

`device` can be either a preset string or an 11-key mapping. Writing a preset
over the mapping form would silently drop a custom profile, so the writer
refuses that assignment and the UI row disables itself when it sees one.

## Testing

968/970 ctest. The two failures also reproduce on `main` and touch no file in
this diff: `compatibility_gate_test.sh` doesn't set the env vars
`single_instance_lock.cc:180` now requires, and `python-capstone` isn't
available on my distro.

The writer has 15 tests, including a round trip over
`config/mocktail.example.yaml`: comment count unchanged, the diff is exactly the
value lines that were assigned, and the result reloads through
`LoadRuntimeConfig`.

The window was also driven end to end against a real config under ASan and
UBSan, with no reports.

<img width="625" height="749" alt="image" src="https://github.com/user-attachments/assets/f25109ed-2c45-4e3c-b648-16d931a5a3c8" />

<img width="635" height="741" alt="image" src="https://github.com/user-attachments/assets/b91e45e0-a4a6-4779-8042-722d888d2630" />
