### PR TITLE
fix(window): stop the window from shrinking to an unpresentable size

### DIFF
--- a/src/window/window.cc
+++ b/src/window/window.cc
@@ -150,6 +150,18 @@ static char g_preferred_gles_library[4096];
 static bool g_auto_angle_retry_attempted = false;
 static std::filesystem::path g_window_state_path;
 
+// Floors the live window at the size a restored geometry already has to clear.
+void ApplyMinimumWindowSize(SDL_Window* window) {
+  if (window == nullptr) {
+    return;
+  }
+  if (!SDL_SetWindowMinimumSize(window, kMinimumWindowWidth,
+                                kMinimumWindowHeight)) {
+    std::fprintf(stderr, "  [window] SDL minimum size rejected: %s\n",
+                 SDL_GetError());
+  }
+}
+
 void ApplyWindowIcon(SDL_Window* window) {
   const Status status = platform::ApplySdlWindowIcon(window);
   if (!status.ok()) {
@@ -791,6 +803,7 @@ bool CreateSoftwareWaitingWindow(int width, int height, const char* title) {
     return false;
   }
   ApplyWindowIcon(g_state.sdl_window);
+  ApplyMinimumWindowSize(g_state.sdl_window);
   ApplyRestoredWindowPosition();
 
   g_state.software_window = true;
@@ -930,6 +943,7 @@ bool Init(int width, int height, const char* title) {
       return false;
     }
     ApplyWindowIcon(g_state.sdl_window);
+    ApplyMinimumWindowSize(g_state.sdl_window);
     ApplyRestoredWindowPosition();
     g_state.direct_vulkan = true;
     g_state.initialised = true;
@@ -1076,6 +1090,7 @@ bool Init(int width, int height, const char* title) {
     return CreateSoftwareWaitingWindow(width, height, title);
   }
   ApplyWindowIcon(g_state.sdl_window);
+  ApplyMinimumWindowSize(g_state.sdl_window);
   ApplyRestoredWindowPosition();
   fprintf(stderr, "  [window] SDL3 window created (%dx%d)\n", width, height);
   ShowWindowAccordingToStartupMode();

--- a/src/window/window_state_store.cc
+++ b/src/window/window_state_store.cc
@@ -21,8 +21,6 @@ namespace {
 
 constexpr int kSchemaVersion = 1;
 constexpr std::uintmax_t kMaximumStateBytes = 32U * 1024U;
-constexpr int kMinimumWidth = 160;
-constexpr int kMinimumHeight = 120;
 constexpr int kMaximumExtent = 16384;
 constexpr int kMaximumCoordinateMagnitude = 131072;
 std::atomic<std::uint64_t> g_temporary_sequence{0};
@@ -74,8 +72,10 @@ bool WriteAll(int descriptor, std::string_view bytes) {
 }
 
 bool IsValidState(const PersistedWindowState& state) {
-  return state.width >= kMinimumWidth && state.width <= kMaximumExtent &&
-         state.height >= kMinimumHeight && state.height <= kMaximumExtent &&
+  return state.width >= kMinimumWindowWidth &&
+         state.width <= kMaximumExtent &&
+         state.height >= kMinimumWindowHeight &&
+         state.height <= kMaximumExtent &&
          (!state.has_position || (state.x >= -kMaximumCoordinateMagnitude &&
                                   state.x <= kMaximumCoordinateMagnitude &&
                                   state.y >= -kMaximumCoordinateMagnitude &&

--- a/src/window/window_state_store.h
+++ b/src/window/window_state_store.h
@@ -8,6 +8,11 @@
 namespace mocktail {
 namespace window {
 
+// Smallest window the renderer is expected to cope with. A restored geometry
+// below this is rejected, and the live window is floored at the same size.
+inline constexpr int kMinimumWindowWidth = 160;
+inline constexpr int kMinimumWindowHeight = 120;
+
 // Windowed geometry remains separate from fullscreen/maximized state so a
 // compositor transition cannot replace the useful restore rectangle with the
 // monitor-sized surface extent.

--- a/tests/window_state_store_test.cc
+++ b/tests/window_state_store_test.cc
@@ -88,6 +88,16 @@ TEST(WindowStateStoreTest, RejectsMalformedAndOutOfRangeState) {
   invalid.width = 100000;
   EXPECT_FALSE(StoreWindowState(path, invalid).ok());
 
+  // The same floor the live window is clamped to.
+  PersistedWindowState too_small;
+  too_small.width = kMinimumWindowWidth - 1;
+  EXPECT_FALSE(StoreWindowState(path, too_small).ok());
+  too_small.width = kMinimumWindowWidth;
+  too_small.height = kMinimumWindowHeight - 1;
+  EXPECT_FALSE(StoreWindowState(path, too_small).ok());
+  too_small.height = kMinimumWindowHeight;
+  EXPECT_TRUE(StoreWindowState(path, too_small).ok());
+
   {
     std::ofstream output(path);
     output << R"({"schema_version":1,"fullscreen":false,)"


### PR DESCRIPTION
Closes #74.

## The bug

Dragging the window down to its smallest size crashes the client. The report is
on COSMIC, where the compositor lets a client with no minimum size hint shrink
until the surface is effectively invisible.

## Cause

`SDL_SetWindowMinimumSize` is never called anywhere in the tree, so no floor is
ever advertised to the compositor.

The inconsistency is already visible in the code: `window_state_store.cc`
refuses to restore a geometry below 160x120, so the live window could be dragged
far below a size the same file treats as invalid to load.

## Fix

Share those bounds from `window_state_store.h` and apply them to every window
Mocktail creates — the Vulkan window, the OpenGL/ANGLE window, and the software
waiting window.

## Verification

With the change, the X11 entry carries the hint a compositor clamps interactive
resizing against:

    $ xprop -id <window> WM_NORMAL_HINTS
    WM_NORMAL_HINTS(WM_SIZE_HINTS):
            program specified minimum size: 160 by 120

Wayland gets the equivalent `xdg_toplevel` minimum from the same SDL call.

`window_state_store_test` now pins both directions of the shared floor, so the
constants cannot drift from what the store validates.

I could not reproduce the crash itself on my hardware (KDE/Wayland, RADV), so I
have not identified the exact failure inside the renderer at a near-zero extent.
This removes the state that triggers it rather than fixing what breaks in it —
happy to dig further if you would rather have the root cause.

https://private-user-images.githubusercontent.com/161503241/641427047-02d4e2d6-9c89-4e80-b3cd-9bea6221f7e5.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODc3NDQ0ODksIm5iZiI6MTc4Nzc0NDE4OSwicGF0aCI6Ii8xNjE1MDMyNDEvNjQxNDI3MDQ3LTAyZDRlMmQ2LTljODktNGU4MC1iM2NkLTliZWE2MjIxZjdlNS5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwODI2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDgyNlQxMTM2MjlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1mNWQwNDAxNzRiYTYzOWMwZjZiMzRkMjFjYTM1NDFmNDk3Mzc4YzU1YTExZGU2NWU5OTMwOGJmYzM4ZWQ4MmU4JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9dmlkZW8lMkZtcDQifQ.WZFRiWs9lSH-UCjWB1mA-2FN7BfkZVVRAhM4Hql5kOw