### PR TITLE
Add a standard way so the issues don't become a mess

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -26,6 +26,8 @@ with your text editor of preference search for "graphics"
 
 change the display value to your desired fps, also turn off vsync if you want more fps than your display supports
 
+---
+
 ### How do I submit an issue?
 
 To make a more standard way so this don't becomes a mess you should follow this to make an issue:

--- a/FAQ.md
+++ b/FAQ.md
@@ -3,6 +3,7 @@
 ------
 
 [How do I change my FPS?](#how-do-i-change-my-fps)
+
 [How do I submit an issue?](#how-do-i-submit-an-issue)
 
 
@@ -28,3 +29,41 @@ change the display value to your desired fps, also turn off vsync if you want mo
 ### How do I submit an issue?
 
 To make a more standard way so this don't becomes a mess you should follow this to make an issue:
+
+First check if the issue already exists or has been solved, we want to avoid duplicates so we don't talk about some issue in a lot of places, if you are sure there is no issue related to you then you can follow this template
+```text
+What have you done before this issue:
+
+
+Problem Description:
+
+
+Steps to replicate:
+
+
+Environment:
+
+```
+
+And an example on how a good issue would look:
+
+```text
+What have you done before this issue:
+I have searched if there was a similar issue and didn't found anything, I have already tried to build from source, installing from flatpak, using the AUR but nothing
+
+Problem Description:
+When I write text in the chat it dissapears until I click something else
+
+Steps to replicate:
+1.Open mocktail in any version(mocktail, mocktail-git and the flatpak version)
+2.Enter any game
+3.Write in chat
+
+Environment:
+OS:Arch Linux
+desktop:KDE plasma
+CPU: Intel Pentium Processor 1405
+GPU: NVIDIA GeForce RTX 6090
+```
+
+Remember if its a duplicate it could get closed so keep that in mind before you make a whole, well written issue

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,7 +1,5 @@
 # Frequently asked questions
 
-------
-
 [How do I change my FPS?](#how-do-i-change-my-fps)
 
 [How do I submit an issue?](#how-do-i-submit-an-issue)

--- a/FAQ.md
+++ b/FAQ.md
@@ -40,6 +40,8 @@ Problem Description:
 
 Steps to replicate:
 
+(optional)Log:
+
 
 Environment:
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -40,6 +40,7 @@ Problem Description:
 
 Steps to replicate:
 
+
 (optional)Log:
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,12 @@
 # Frequently asked questions
 
-[How do I change my FPS?](/FAQ.md#how-do-i-change-my-fps)
+------
+
+[How do I change my FPS?](#how-do-i-change-my-fps)
+[How do I submit an issue?](#how-do-i-submit-an-issue)
+
+
+-----
 
 ### How do I change my FPS?
 
@@ -18,3 +24,7 @@ with your text editor of preference search for "graphics"
 
 
 change the display value to your desired fps, also turn off vsync if you want more fps than your display supports
+
+### How do I submit an issue?
+
+To make a more standard way so this don't becomes a mess you should follow this to make an issue:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Put a JSON object in `$XDG_CONFIG_HOME/mocktail/fflags.json` (usually
   "DFIntExample": "120"
 }
 ```
+## How Do I submit an issue?
+
+Go check [FAQ.md](FAQ.md)
+
 ## FAQ
 
 To see the most Frequently Asked Question go check [FAQ.md](FAQ.md)


### PR DESCRIPTION
Just a little section on FAQ.md and an edit in README.md so people know how to submit an issue in a way this doesn't become a mess(If i remember correctly there is a way to add the template when opening an issue but idk)