### PR TITLE
feat(graphics): system-EGL OpenGL backend with NVIDIA performance tun…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,23 @@ target_compile_definitions(mocktail_legacy_runtime PRIVATE
 add_executable(mocktail src/main.cc)
 target_include_directories(mocktail PRIVATE include src)
 mocktail_apply_compile_options(mocktail)
+
+# GLES version-pin shim for the system-egl (OpenGL) backend. Loaded in place of
+# the host libEGL.so so eglCreateContext/eglGetProcAddress can force the GLES
+# major/minor requested via MOCKTAIL_SYSTEM_GLES_VERSION.
+add_library(mocktail_egl_shim SHARED src/graphics/egl_version_shim.cc)
+target_link_libraries(mocktail_egl_shim PRIVATE EGL ${CMAKE_DL_LIBS})
+set_target_properties(mocktail_egl_shim PROPERTIES
+  OUTPUT_NAME mocktail_egl_shim
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+add_dependencies(mocktail mocktail_egl_shim)
+
+add_library(mocktail_egl_vsync_shim SHARED src/graphics/egl_swap_interval_shim.cc)
+target_link_libraries(mocktail_egl_vsync_shim PRIVATE ${CMAKE_DL_LIBS})
+set_target_properties(mocktail_egl_vsync_shim PROPERTIES
+  OUTPUT_NAME mocktail_egl_vsync_shim
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+add_dependencies(mocktail mocktail_egl_vsync_shim)
 target_compile_definitions(mocktail PRIVATE
   "MOCKTAIL_DEFAULT_COMPATIBILITY_MANIFEST=\"${MOCKTAIL_DEFAULT_COMPATIBILITY_MANIFEST}\""
 )

--- a/cmake/MocktailPlatformGraphics.cmake
+++ b/cmake/MocktailPlatformGraphics.cmake
@@ -90,6 +90,8 @@ add_library(mocktail_graphics_foundation STATIC
   ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/src/graphics/graphics_backend.cc
   ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/src/graphics/angle_probe.cc
   ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/src/graphics/bionic_egl_bridge.cc
+  ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/src/graphics/system_egl_probe.cc
+  ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/src/graphics/system_egl_bridge.cc
 )
 target_include_directories(mocktail_graphics_foundation
   PUBLIC ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/include
@@ -131,6 +133,13 @@ if(BUILD_TESTING AND TARGET GTest::gtest_main)
   add_executable(platform_graphics_foundation_test
     ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/tests/platform_graphics_foundation_test.cc
   )
+  add_executable(system_egl_probe_test
+    ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/tests/system_egl_probe_test.cc
+  )
+  target_link_libraries(system_egl_probe_test PRIVATE
+    Mocktail::GraphicsFoundation
+    GTest::gtest_main
+  )
   add_executable(display_refresh_capabilities_test
     ${MOCKTAIL_PLATFORM_GRAPHICS_ROOT}/tests/display_refresh_capabilities_test.cc
   )
@@ -154,6 +163,7 @@ if(BUILD_TESTING AND TARGET GTest::gtest_main)
   include(GoogleTest)
   gtest_discover_tests(bionic_egl_bridge_test)
   gtest_discover_tests(platform_graphics_foundation_test)
+  gtest_discover_tests(system_egl_probe_test)
   gtest_discover_tests(display_refresh_capabilities_test)
   gtest_discover_tests(present_mode_policy_test)
 endif()

--- a/config/mocktail.example.yaml
+++ b/config/mocktail.example.yaml
@@ -43,6 +43,11 @@ graphics:
   # Supported values: display, unlimited, 30, 60, 120, 144, 240. Unlimited
   # selects Roblox's unmodified 240-FPS scheduler maximum.
   frame_rate_limit: display
+  # String/integer (default: auto): pin the OpenGL ES client version for the
+  # system-egl (OpenGL) backend. Supported: auto, 3.0, 3.1, 3.2 (or 30/31/32).
+  # auto lets the driver and Roblox negotiate the highest compatible version;
+  # forcing 3.0/3.1/3.2 overrides EGL_CONTEXT_CLIENT_VERSION at context creation.
+  gles_version: auto
   # String (default: auto): presentation synchronization: auto, on, or off.
   vsync: auto
 

--- a/config/roblox_payload.json
+++ b/config/roblox_payload.json
@@ -1,23 +1,25 @@
 {
   "schema_version": 1,
   "package": "com.roblox.client",
-  "version_name": "2.725.1142",
-  "version_code": 2546,
+  "version_name": "2.734.917",
+  "version_code": 2908,
   "abi": "x86_64",
-  "elf_build_id": "d0cb1fa0deb3d9161b4cd77530cbcd2e50de3a21",
+  "elf_build_id": "63c5109637b7d7b2bdb8ed8f858023ff5ef49326",
   "sha256": {
-    "libroblox": "92ca0e4d8bc4e1c7a37fc2b52544869299ec8b9a40ea8da96ebac66660e0b1af",
-    "base_apk": "eba476fec3020eaceb28436c1d160eb35d6689d8ffb060e09678535584babc7a",
-    "x86_64_split_apk": "5c4193c9700481079cee958b38ba9cbb97768b0a130b7f704ed084753f01ce2b"
+    "libroblox": "72c3b1a5c151b5ac0bfc5394ce3a91775884fbd777589ccab8ac1c4f9885f739",
+    "base_apk": "0bdf692dd395d7df94cae5cf5d37a3ba209d0a5f9e6562bab5dcbca7203437ab",
+    "x86_64_split_apk": "0bdf692dd395d7df94cae5cf5d37a3ba209d0a5f9e6562bab5dcbca7203437ab"
   },
   "signing_certificates_sha256": [
     "2bebd189e8d3106401347056c93d045b61e20e22d0c3cbed85474aeb00a3d12a",
     "44932ea35a17a267372d71b54d1a0cb3da0dca5113e94406ae2fe18090ba1477"
   ],
   "assets": {
-    "file_count": 1837
+    "file_count": 1835,
+    "sha256_tree": "2084278b7d0f03ad5bd16512827a59527d2e14e8eb1ced08f8abc6e7b3940cff"
   },
   "source": "sober-update-service",
-  "imported_at": "2026-07-09T19:12:54Z",
-  "compatibility_status": "supported"
+  "imported_at": "2026-08-27T17:12:08Z",
+  "compatibility_status": "unverified",
+  "apk_layout": "monolithic"
 }

--- a/include/mocktail/graphics/system_egl_bridge.h
+++ b/include/mocktail/graphics/system_egl_bridge.h
@@ -1,0 +1,51 @@
+#ifndef MOCKTAIL_GRAPHICS_SYSTEM_EGL_BRIDGE_H_
+#define MOCKTAIL_GRAPHICS_SYSTEM_EGL_BRIDGE_H_
+
+#include <string>
+#include <unordered_map>
+
+#include <dlfcn.h>
+
+namespace mocktail {
+namespace graphics {
+
+// Loads the host system EGL and OpenGL ES drivers and exposes their entry
+// points to the Bionic guest when the system-egl (OpenGL) backend is selected.
+//
+// This is the routing counterpart of BionicEglBridge: instead of handing the
+// Android client Mocktail's own libEGL.so shim, the loader resolver points the
+// guest's libEGL.so/libGLESv2.so synthetic symbols at the resolved addresses
+// from the host system libraries so Roblox renders through the native GL stack
+// (Mesa, NVIDIA, etc.) instead of ANGLE.
+class SystemEglBridge final {
+ public:
+  bool Load();
+  bool loaded() const { return handle_ != nullptr; }
+  bool IsLoaded() const { return handle_ != nullptr; }
+  void* handle() const { return handle_; }
+  void* gles_handle() const { return gles_handle_; }
+  const std::string& error() const { return error_; }
+  const std::string& egl_library_path() const { return egl_library_path_; }
+  const std::string& gles_library_path() const { return gles_library_path_; }
+  const std::unordered_map<std::string, void*>& exports() const {
+    return exports_;
+  }
+  void* Find(const char* name) const;
+
+  // Path to the GLES-version shim (libmocktail_egl_shim.so) next to the
+  // running executable.
+  static std::string ShimLibraryPath();
+
+ private:
+  void* handle_ = nullptr;
+  void* gles_handle_ = nullptr;
+  std::string error_;
+  std::string egl_library_path_;
+  std::string gles_library_path_;
+  std::unordered_map<std::string, void*> exports_;
+};
+
+}  // namespace graphics
+}  // namespace mocktail
+
+#endif  // MOCKTAIL_GRAPHICS_SYSTEM_EGL_BRIDGE_H_

--- a/include/mocktail/graphics/system_egl_probe.h
+++ b/include/mocktail/graphics/system_egl_probe.h
@@ -1,0 +1,31 @@
+#ifndef MOCKTAIL_GRAPHICS_SYSTEM_EGL_PROBE_H_
+#define MOCKTAIL_GRAPHICS_SYSTEM_EGL_PROBE_H_
+
+#include <string>
+
+#include "mocktail/graphics/graphics_backend.h"
+
+namespace mocktail {
+namespace graphics {
+
+// Options for probing the host system OpenGL/EGL stack. When the library paths
+// are left empty the loader resolves the platform SONAMEs (libEGL.so.1 and
+// libGLESv2.so.2) from the host loader search path rather than from a pinned
+// ANGLE or Mocktail bridge distribution.
+struct SystemEglProbeOptions {
+  std::string egl_library_path;
+  std::string gles_library_path;
+  bool allow_software_device = false;
+};
+
+// Loads the host system EGL/GLES pair, initializes a surfaceless EGL display,
+// and validates a real OpenGL ES context. No draw calls are issued. The result
+// reports hardware vs software acceleration by inspecting the GL_RENDERER and
+// GL_VENDOR strings (llvmpipe, swiftshader, softpipe and similar are treated as
+// software rasterizers).
+BackendCapability ProbeSystemEgl(const SystemEglProbeOptions& options);
+
+}  // namespace graphics
+}  // namespace mocktail
+
+#endif  // MOCKTAIL_GRAPHICS_SYSTEM_EGL_PROBE_H_

--- a/include/runtime/runtime_config.h
+++ b/include/runtime/runtime_config.h
@@ -80,6 +80,8 @@ class RuntimeConfig {
   const std::string& graphics_backend_name() const {
     return graphics_backend_name_;
   }
+  // system-egl (OpenGL) backend GLES version pin: 0 = auto, 30/31/32 = force.
+  int system_egl_gles_version() const { return system_egl_gles_version_; }
   const WindowConfig& window() const { return window_; }
   const std::string& theme_mode() const { return theme_mode_; }
   bool theme_mode_valid() const {
@@ -134,6 +136,7 @@ class RuntimeConfig {
   std::filesystem::path roblox_library_path_ = "rbx_bin/libroblox.so";
   GraphicsBackend graphics_backend_ = GraphicsBackend::kVulkan;
   std::string graphics_backend_name_ = "direct-vulkan";
+  int system_egl_gles_version_ = 0;
   WindowConfig window_;
   std::string theme_mode_ = "system";
   InputCapabilityConfig input_capabilities_;

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Launch Mocktail with NVIDIA-specific tuning to reduce lag spikes / stutter
+# on Linux (GPU clock-scaling hitches, vsync, compositor contention).
+set -e
+cd "$(dirname "$0")"
+
+# Pin the GPU clocks so PowerMizer stops ramping them up/down under varying
+# load -- this is the #1 cause of periodic hitches on NVIDIA Linux.
+# (SyncToVBlank is managed by the binary from graphics.vsync in config.yaml,
+# so do NOT force it here.)
+if command -v nvidia-settings >/dev/null 2>&1; then
+  nvidia-settings -a '[gpu:0]/GPUPowerMizerMode=1' >/dev/null 2>&1 || true
+fi
+
+# Threaded GL command submission + compositor bypass at the driver level.
+export __GL_THREADED_OPTIMIZATIONS=1
+# Bypass the X11 compositor for our window to avoid compositor-induced hitches.
+export SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR=1
+
+export MOCKTAIL_SKIP_UPDATE_CHECK=1
+export ROBLOX_LIB_PATH="$PWD/rbx_bin/libroblox.so"
+export MOCKTAIL_ASSET_PATH="$PWD/rbx_bin/assets/content"
+export MOCKTAIL_DEBUG_SHOW_WINDOW_BEFORE_FRAME=1
+
+# Preload the vsync interposer so eglSwapInterval(1) requests become 0 when
+# graphics.vsync=off (unlocks the frame rate past the display refresh rate).
+export LD_PRELOAD="$PWD/build/libmocktail_egl_vsync_shim.so${LD_PRELOAD:+:$LD_PRELOAD}"
+
+exec ./build/mocktail "$@"

--- a/src/graphics/egl_swap_interval_shim.cc
+++ b/src/graphics/egl_swap_interval_shim.cc
@@ -1,0 +1,31 @@
+// LD_PRELOAD interposer that neutralises application-requested vsync.
+//
+// Roblox (and SDL) request vsync via eglSwapInterval(1). The NVIDIA driver's
+// __GL_SYNC_TO_VBLANK=0 does NOT override an explicit application request, so
+// the frame rate stays capped to the display refresh rate. This library forces
+// every eglSwapInterval call to 0 while MOCKTAIL_VSYNC=off, which is required
+// to unlock the frame rate. When vsync is not off the call passes through
+// unchanged, so the library is safe to always preload.
+
+#include <EGL/egl.h>
+#include <dlfcn.h>
+#include <cstdlib>
+#include <cstring>
+
+typedef EGLBoolean (*PFN_eglSwapInterval)(EGLDisplay, EGLint);
+
+extern "C" EGLBoolean eglSwapInterval(EGLDisplay dpy, EGLint interval) {
+  static PFN_eglSwapInterval real = nullptr;
+  if (real == nullptr) {
+    real = reinterpret_cast<PFN_eglSwapInterval>(
+        dlsym(RTLD_NEXT, "eglSwapInterval"));
+  }
+  const char* vsync = std::getenv("MOCKTAIL_VSYNC");
+  if (vsync != nullptr && std::strcmp(vsync, "off") == 0) {
+    interval = 0;
+  }
+  if (real == nullptr) {
+    return EGL_FALSE;
+  }
+  return real(dpy, interval);
+}

--- a/src/graphics/egl_version_shim.cc
+++ b/src/graphics/egl_version_shim.cc
@@ -1,0 +1,131 @@
+// GLES version-pin shim for the system-egl (OpenGL) backend.
+//
+// This is loaded in place of the host libEGL.so as the guest's libEGL.so
+// (exact_adapter). It links against the real libEGL so every EGL call forwards
+// transparently, while overriding eglCreateContext and eglGetProcAddress to
+// force the OpenGL ES major/minor version requested via
+// MOCKTAIL_SYSTEM_GLES_VERSION (30/31/32). This catches both the direct symbol
+// path and the eglGetProcAddress path that the guest may use.
+
+#include <EGL/egl.h>
+
+#include <dlfcn.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifndef EGL_CONTEXT_MINOR_VERSION
+#define EGL_CONTEXT_MINOR_VERSION 0x30FB
+#endif
+
+namespace {
+
+int g_requested_minor = -1;  // -1 means "auto" (pass through untouched).
+
+using EglCreateContextFn = EGLContext (*)(EGLDisplay, EGLConfig, EGLContext,
+                                          const EGLint*);
+using EglGetProcAddressFn = decltype(&::eglGetProcAddress);
+
+EglCreateContextFn g_real_create_context = nullptr;
+EglGetProcAddressFn g_real_get_proc_address = nullptr;
+
+void ResolveReal() {
+  if (g_real_create_context != nullptr) {
+    return;
+  }
+  void* real_egl = ::dlopen("libEGL.so.1", RTLD_LAZY | RTLD_NOLOAD);
+  if (real_egl == nullptr) {
+    real_egl = ::dlopen("libEGL.so.1", RTLD_LAZY);
+  }
+  if (real_egl == nullptr) {
+    real_egl = ::dlopen("libEGL.so", RTLD_LAZY);
+  }
+  if (real_egl == nullptr) {
+    return;
+  }
+  g_real_create_context =
+      reinterpret_cast<EglCreateContextFn>(::dlsym(real_egl, "eglCreateContext"));
+  g_real_get_proc_address = reinterpret_cast<EglGetProcAddressFn>(
+      ::dlsym(real_egl, "eglGetProcAddress"));
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((constructor)) void mocktail_egl_shim_init() {
+  const char* version = std::getenv("MOCKTAIL_SYSTEM_GLES_VERSION");
+  if (version == nullptr || version[0] == '\0') {
+    return;
+  }
+  const std::string v(version);
+  if (v == "30" || v == "3.0") {
+    g_requested_minor = 0;
+  } else if (v == "31" || v == "3.1") {
+    g_requested_minor = 1;
+  } else if (v == "32" || v == "3.2") {
+    g_requested_minor = 2;
+  }
+  ResolveReal();
+}
+
+EGLContext eglCreateContext(EGLDisplay display, EGLConfig config,
+                            EGLContext share_context,
+                            const EGLint* attribs) {
+  if (g_requested_minor < 0 || g_real_create_context == nullptr) {
+    return g_real_create_context == nullptr
+               ? EGL_NO_CONTEXT
+               : g_real_create_context(display, config, share_context, attribs);
+  }
+
+  std::vector<EGLint> attrs;
+  bool saw_major = false;
+  bool saw_minor = false;
+  for (const EGLint* p = attribs; p != nullptr && *p != EGL_NONE; p += 2) {
+    const EGLint key = p[0];
+    const EGLint value = p[1];
+    if (key == EGL_CONTEXT_CLIENT_VERSION) {
+      attrs.push_back(key);
+      attrs.push_back(3);  // Force OpenGL ES 3.x.
+      saw_major = true;
+    } else if (key == EGL_CONTEXT_MINOR_VERSION) {
+      attrs.push_back(key);
+      attrs.push_back(g_requested_minor);
+      saw_minor = true;
+    } else {
+      attrs.push_back(key);
+      attrs.push_back(value);
+    }
+  }
+  if (!saw_major) {
+    attrs.push_back(EGL_CONTEXT_CLIENT_VERSION);
+    attrs.push_back(3);
+  }
+  if (!saw_minor) {
+    attrs.push_back(EGL_CONTEXT_MINOR_VERSION);
+    attrs.push_back(g_requested_minor);
+  }
+  attrs.push_back(EGL_NONE);
+
+  return g_real_create_context(display, config, share_context, attrs.data());
+}
+
+EGLAPI __eglMustCastToProperFunctionPointerType EGLAPIENTRY
+eglGetProcAddress(const char* name) {
+  if (g_requested_minor >= 0 && name != nullptr &&
+      std::strcmp(name, "eglCreateContext") == 0) {
+    return reinterpret_cast<__eglMustCastToProperFunctionPointerType>(
+        &eglCreateContext);
+  }
+  if (g_real_get_proc_address != nullptr) {
+    return g_real_get_proc_address(name);
+  }
+  ResolveReal();
+  return g_real_get_proc_address == nullptr ? nullptr
+                                            : g_real_get_proc_address(name);
+}
+
+}  // extern "C"

--- a/src/graphics/system_egl_bridge.cc
+++ b/src/graphics/system_egl_bridge.cc
@@ -1,0 +1,288 @@
+// Loads the host system EGL/OpenGL ES drivers for the system-egl (OpenGL)
+// backend and exposes their entry points to the Bionic guest.
+
+#include "mocktail/graphics/system_egl_bridge.h"
+
+#include <EGL/egl.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <limits.h>
+#include <string>
+#include <vector>
+
+namespace mocktail {
+namespace graphics {
+namespace {
+
+constexpr const char* kDefaultEglLibrary = "libEGL.so.1";
+constexpr const char* kDefaultGlesLibrary = "libGLESv2.so.2";
+
+constexpr const char* kEglExportNames[] = {
+    "eglBindAPI",
+    "eglChooseConfig",
+    "eglCreateContext",
+    "eglCreatePbufferSurface",
+    "eglCreateWindowSurface",
+    "eglDestroyContext",
+    "eglDestroySurface",
+    "eglGetConfigAttrib",
+    "eglGetCurrentContext",
+    "eglGetCurrentDisplay",
+    "eglGetCurrentSurface",
+    "eglGetDisplay",
+    "eglGetError",
+    "eglGetProcAddress",
+    "eglInitialize",
+    "eglMakeCurrent",
+    "eglQueryString",
+    "eglQuerySurface",
+    "eglSwapBuffers",
+    "eglSwapInterval",
+    "eglTerminate",
+};
+
+constexpr const char* kGlesExportNames[] = {
+    "glActiveTexture",
+    "glAttachShader",
+    "glBindAttribLocation",
+    "glBindBuffer",
+    "glBindFramebuffer",
+    "glBindTexture",
+    "glBlendFunc",
+    "glClear",
+    "glClearColor",
+    "glCompileShader",
+    "glCreateProgram",
+    "glCreateShader",
+    "glDeleteBuffers",
+    "glDeleteProgram",
+    "glDeleteShader",
+    "glDeleteTextures",
+    "glDrawElements",
+    "glEnable",
+    "glEnableVertexAttribArray",
+    "glGetAttribLocation",
+    "glGetError",
+    "glGetIntegerv",
+    "glGetProgramiv",
+    "glGetShaderiv",
+    "glGetString",
+    "glGetUniformLocation",
+    "glLinkProgram",
+    "glShaderSource",
+    "glTexImage2D",
+    "glTexParameteri",
+    "glUniform1f",
+    "glUniform1i",
+    "glUniformMatrix4fv",
+    "glUseProgram",
+    "glVertexAttribPointer",
+    "glViewport",
+};
+
+}  // namespace
+
+namespace {
+
+using EglCreateContextFn = EGLContext (*)(EGLDisplay, EGLConfig, EGLContext,
+                                         const EGLint*);
+
+#ifndef EGL_CONTEXT_MINOR_VERSION
+#define EGL_CONTEXT_MINOR_VERSION 0x30FB
+#endif
+
+// Configured by SystemEglBridge::Load from MOCKTAIL_SYSTEM_GLES_VERSION.
+// 0 = auto (let the driver and Roblox negotiate); 30/31/32 force GLES 3.0/3.1/3.2.
+int g_requested_gles_version = 0;
+EglCreateContextFn g_real_egl_create_context = nullptr;
+
+EGLContext WrapEglCreateContext(EGLDisplay display, EGLConfig config,
+                                EGLContext share_context,
+                                const EGLint* attribs) {
+  if (g_real_egl_create_context == nullptr) {
+    return EGL_NO_CONTEXT;
+  }
+  if (g_requested_gles_version == 0) {
+    // No pin requested: behave exactly like the host driver.
+    return g_real_egl_create_context(display, config, share_context, attribs);
+  }
+  const EGLint requested_major = 3;
+  const EGLint requested_minor = (g_requested_gles_version == 32) ? 2
+                                 : (g_requested_gles_version == 31) ? 1
+                                 : 0;
+  std::vector<EGLint> attrs;
+  bool saw_major = false;
+  bool saw_minor = false;
+  for (const EGLint* p = attribs; p != nullptr && *p != EGL_NONE; p += 2) {
+    const EGLint key = p[0];
+    const EGLint value = p[1];
+    if (key == EGL_CONTEXT_CLIENT_VERSION) {
+      attrs.push_back(key);
+      attrs.push_back(requested_major);
+      saw_major = true;
+    } else if (key == EGL_CONTEXT_MINOR_VERSION) {
+      attrs.push_back(key);
+      attrs.push_back(requested_minor);
+      saw_minor = true;
+    } else {
+      attrs.push_back(key);
+      attrs.push_back(value);
+    }
+  }
+  if (!saw_major) {
+    attrs.push_back(EGL_CONTEXT_CLIENT_VERSION);
+    attrs.push_back(requested_major);
+  }
+  if (!saw_minor) {
+    attrs.push_back(EGL_CONTEXT_MINOR_VERSION);
+    attrs.push_back(requested_minor);
+  }
+  attrs.push_back(EGL_NONE);
+  return g_real_egl_create_context(display, config, share_context,
+                                  attrs.data());
+}
+
+}  // namespace
+
+bool SystemEglBridge::Load() {
+  if (handle_ != nullptr) {
+    return true;
+  }
+
+  exports_.clear();
+  error_.clear();
+  egl_library_path_.clear();
+  gles_library_path_.clear();
+
+  const char* egl_override = std::getenv("MOCKTAIL_SYSTEM_EGL_LIBRARY");
+  const char* gles_override = std::getenv("MOCKTAIL_SYSTEM_GLES_LIBRARY");
+  egl_library_path_ =
+      egl_override != nullptr && egl_override[0] != '\0' ? egl_override : kDefaultEglLibrary;
+  gles_library_path_ = gles_override != nullptr && gles_override[0] != '\0'
+                           ? gles_override
+                           : kDefaultGlesLibrary;
+
+  dlerror();
+  void* egl_handle = ::dlopen(egl_library_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (egl_handle == nullptr) {
+    const char* loader_error = ::dlerror();
+    error_ = "could not load system EGL library '" + egl_library_path_ + "'";
+    if (loader_error != nullptr) {
+      error_ += ": ";
+      error_ += loader_error;
+    }
+    return false;
+  }
+
+  dlerror();
+  void* gles_handle = ::dlopen(gles_library_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (gles_handle == nullptr) {
+    const char* loader_error = ::dlerror();
+    error_ = "could not load system GLES library '" + gles_library_path_ + "'";
+    if (loader_error != nullptr) {
+      error_ += ": ";
+      error_ += loader_error;
+    }
+    ::dlclose(egl_handle);
+    return false;
+  }
+
+  for (const char* name : kEglExportNames) {
+    void* address = ::dlsym(egl_handle, name);
+    if (address == nullptr) {
+      error_ = "system EGL library is missing export '";
+      error_ += name;
+      error_ += "'";
+      ::dlclose(gles_handle);
+      ::dlclose(egl_handle);
+      exports_.clear();
+      return false;
+    }
+    if (std::strcmp(name, "eglCreateContext") == 0) {
+      g_real_egl_create_context =
+          reinterpret_cast<EglCreateContextFn>(address);
+    }
+    exports_.emplace(name, address);
+  }
+
+  for (const char* name : kGlesExportNames) {
+    void* address = ::dlsym(gles_handle, name);
+    if (address == nullptr) {
+      error_ = "system GLES library is missing export '";
+      error_ += name;
+      error_ += "'";
+      ::dlclose(gles_handle);
+      ::dlclose(egl_handle);
+      exports_.clear();
+      return false;
+    }
+    exports_.emplace(name, address);
+  }
+
+  const char* gles_version_env = std::getenv("MOCKTAIL_SYSTEM_GLES_VERSION");
+  if (gles_version_env != nullptr && gles_version_env[0] != '\0') {
+    const std::string version_text(gles_version_env);
+    if (version_text == "30" || version_text == "3.0") {
+      g_requested_gles_version = 30;
+    } else if (version_text == "31" || version_text == "3.1") {
+      g_requested_gles_version = 31;
+    } else if (version_text == "32" || version_text == "3.2") {
+      g_requested_gles_version = 32;
+    }
+  }
+  if (g_requested_gles_version != 0 && g_real_egl_create_context != nullptr) {
+    // Interpose eglCreateContext so Roblox's GLES version request is pinned.
+    exports_["eglCreateContext"] =
+        reinterpret_cast<void*>(&WrapEglCreateContext);
+  }
+
+  handle_ = egl_handle;
+  gles_handle_ = gles_handle;
+
+  // When a version pin is requested, load the GLES-version shim and expose it
+  // as the guest's libEGL.so. The shim wraps eglCreateContext/eglGetProcAddress
+  // so the pin is honoured regardless of how the guest resolves the symbols
+  // (direct import or eglGetProcAddress). Other EGL calls forward unchanged.
+  if (g_requested_gles_version != 0) {
+    const std::string shim_path = ShimLibraryPath();
+    ::dlerror();
+    void* shim = ::dlopen(shim_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (shim != nullptr) {
+      handle_ = shim;
+      std::cerr << "[gles-pin] using version shim " << shim_path << '\n';
+    } else {
+      const char* load_error = ::dlerror();
+      std::cerr << "[gles-pin] could not load version shim '" << shim_path
+                << "': " << (load_error != nullptr ? load_error : "unknown")
+                << "; falling back to synthetic-library wrapper\n";
+    }
+  }
+
+  return true;
+}
+
+std::string SystemEglBridge::ShimLibraryPath() {
+  char buffer[PATH_MAX];
+  const ssize_t length = ::readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+  if (length > 0) {
+    buffer[length] = '\0';
+    const std::string exe(buffer, static_cast<size_t>(length));
+    const auto slash = exe.find_last_of('/');
+    const std::string dir =
+        slash == std::string::npos ? "." : exe.substr(0, slash);
+    return dir + "/libmocktail_egl_shim.so";
+  }
+  return "libmocktail_egl_shim.so";
+}
+
+void* SystemEglBridge::Find(const char* name) const {
+  const auto it = exports_.find(name);
+  return it != exports_.end() ? it->second : nullptr;
+}
+
+}  // namespace graphics
+}  // namespace mocktail

--- a/src/graphics/system_egl_probe.cc
+++ b/src/graphics/system_egl_probe.cc
@@ -1,0 +1,270 @@
+// Host system OpenGL/EGL capability probe for the system-egl (OpenGL) backend.
+
+#include "mocktail/graphics/system_egl_probe.h"
+
+#include <dlfcn.h>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+#include <string>
+#include <utility>
+
+namespace mocktail {
+namespace graphics {
+namespace {
+
+// EGL_PLATFORM_SURFACELESS_MESA from eglext.h, copied so the probe does not
+// depend on a Mesa extension header being present.
+constexpr EGLenum kEglPlatformSurfacelessMesa = 0x31BE;
+
+constexpr const char* kDefaultEglLibrary = "libEGL.so.1";
+constexpr const char* kDefaultGlesLibrary = "libGLESv2.so.2";
+
+constexpr std::uint32_t kGlRenderer = 0x1F01;  // GL_RENDERER
+constexpr std::uint32_t kGlVendor = 0x1F00;    // GL_VENDOR
+
+BackendCapability Unavailable(std::string detail) {
+  return {GraphicsBackendKind::kSystemEgl, CapabilityState::kUnavailable,
+          HardwareAcceleration::kUnknown, std::move(detail)};
+}
+
+std::string DlErrorFor(const char* kind, const std::string& path) {
+  std::string detail = "failed to load ";
+  detail += kind;
+  detail += " library '";
+  detail += path;
+  detail += "': ";
+  const char* error = dlerror();
+  detail += error != nullptr ? error : "unknown dynamic loader error";
+  return detail;
+}
+
+bool HasSymbols(void* handle,
+                const std::initializer_list<const char*>& symbols,
+                std::string* missing_symbol) {
+  for (const char* symbol : symbols) {
+    if (::dlsym(handle, symbol) == nullptr) {
+      if (missing_symbol != nullptr) {
+        *missing_symbol = symbol;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsSoftwareRenderer(const char* renderer, const char* vendor) {
+  auto contains = [](const char* haystack, const char* needle) {
+    if (haystack == nullptr || needle == nullptr) {
+      return false;
+    }
+    const char* found = std::strstr(haystack, needle);
+    return found != nullptr;
+  };
+  auto lower_contains = [&](const char* source, const char* token) {
+    if (source == nullptr) {
+      return false;
+    }
+    std::string lowered;
+    lowered.reserve(std::strlen(source) + 1);
+    for (const char* p = source; *p != '\0'; ++p) {
+      lowered.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(*p))));
+    }
+    return std::strstr(lowered.c_str(), token) != nullptr;
+  };
+  (void)contains;
+  return lower_contains(renderer, "llvmpipe") ||
+         lower_contains(renderer, "swiftshader") ||
+         lower_contains(renderer, "softpipe") ||
+         lower_contains(renderer, "software") ||
+         lower_contains(vendor, "software") ||
+         lower_contains(renderer, "lavapipe");
+}
+
+}  // namespace
+
+BackendCapability ProbeSystemEgl(const SystemEglProbeOptions& options) {
+  const std::string egl_path =
+      options.egl_library_path.empty() ? kDefaultEglLibrary : options.egl_library_path;
+  const std::string gles_path = options.gles_library_path.empty()
+                                    ? kDefaultGlesLibrary
+                                    : options.gles_library_path;
+
+  dlerror();
+  void* egl_handle = ::dlopen(egl_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (egl_handle == nullptr) {
+    return Unavailable(DlErrorFor("EGL", egl_path));
+  }
+  dlerror();
+  void* gles_handle = ::dlopen(gles_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (gles_handle == nullptr) {
+    const std::string detail = DlErrorFor("GLES", gles_path);
+    ::dlclose(egl_handle);
+    return Unavailable(detail);
+  }
+
+  std::string missing;
+  if (!HasSymbols(egl_handle,
+                  {"eglGetProcAddress", "eglInitialize", "eglTerminate",
+                   "eglQueryString", "eglChooseConfig", "eglCreateContext",
+                   "eglCreatePbufferSurface", "eglMakeCurrent",
+                   "eglSwapBuffers", "eglGetDisplay"},
+                  &missing)) {
+    ::dlclose(gles_handle);
+    ::dlclose(egl_handle);
+    return Unavailable("system EGL library is missing required symbol " + missing);
+  }
+
+  auto get_proc_address =
+      reinterpret_cast<PFNEGLGETPROCADDRESSPROC>(::dlsym(egl_handle, "eglGetProcAddress"));
+  auto get_platform_display =
+      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+          ::dlsym(egl_handle, "eglGetPlatformDisplayEXT"));
+  if (get_platform_display == nullptr && get_proc_address != nullptr) {
+    get_platform_display = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+        get_proc_address("eglGetPlatformDisplayEXT"));
+  }
+  auto get_display =
+      reinterpret_cast<PFNEGLGETDISPLAYPROC>(::dlsym(egl_handle, "eglGetDisplay"));
+  auto initialize =
+      reinterpret_cast<PFNEGLINITIALIZEPROC>(::dlsym(egl_handle, "eglInitialize"));
+  auto terminate =
+      reinterpret_cast<PFNEGLTERMINATEPROC>(::dlsym(egl_handle, "eglTerminate"));
+  auto query_string =
+      reinterpret_cast<PFNEGLQUERYSTRINGPROC>(::dlsym(egl_handle, "eglQueryString"));
+  auto choose_config =
+      reinterpret_cast<PFNEGLCHOOSECONFIGPROC>(::dlsym(egl_handle, "eglChooseConfig"));
+  auto create_context =
+      reinterpret_cast<PFNEGLCREATECONTEXTPROC>(::dlsym(egl_handle, "eglCreateContext"));
+  auto create_pbuffer =
+      reinterpret_cast<PFNEGLCREATEPBUFFERSURFACEPROC>(
+          ::dlsym(egl_handle, "eglCreatePbufferSurface"));
+  auto make_current =
+      reinterpret_cast<PFNEGLMAKECURRENTPROC>(::dlsym(egl_handle, "eglMakeCurrent"));
+  auto destroy_surface =
+      reinterpret_cast<PFNEGLDESTROYSURFACEPROC>(::dlsym(egl_handle, "eglDestroySurface"));
+  auto destroy_context =
+      reinterpret_cast<PFNEGLDESTROYCONTEXTPROC>(::dlsym(egl_handle, "eglDestroyContext"));
+
+  EGLDisplay display = EGL_NO_DISPLAY;
+  if (get_platform_display != nullptr) {
+    const EGLint surfaceless[] = {EGL_NONE};
+    display = get_platform_display(kEglPlatformSurfacelessMesa,
+                                   EGL_DEFAULT_DISPLAY, surfaceless);
+  }
+  if (display == EGL_NO_DISPLAY && get_display != nullptr) {
+    display = get_display(EGL_DEFAULT_DISPLAY);
+  }
+  if (display == EGL_NO_DISPLAY) {
+    ::dlclose(gles_handle);
+    ::dlclose(egl_handle);
+    return Unavailable("system EGL could not create a display");
+  }
+
+  EGLint major = 0;
+  EGLint minor = 0;
+  if (initialize(display, &major, &minor) != EGL_TRUE) {
+    terminate(display);
+    ::dlclose(gles_handle);
+    ::dlclose(egl_handle);
+    return Unavailable("system EGL display failed eglInitialize");
+  }
+
+  const EGLint config_attributes[] = {
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+      EGL_NONE,
+  };
+  EGLConfig config = nullptr;
+  EGLint config_count = 0;
+  if (choose_config(display, config_attributes, &config, 1, &config_count) != EGL_TRUE ||
+      config_count == 0) {
+    terminate(display);
+    ::dlclose(gles_handle);
+    ::dlclose(egl_handle);
+    return Unavailable("system EGL has no OpenGL ES 3 capable configuration");
+  }
+
+  const EGLint context_attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
+  EGLContext context =
+      create_context(display, config, EGL_NO_CONTEXT, context_attributes);
+  if (context == EGL_NO_CONTEXT) {
+    terminate(display);
+    ::dlclose(gles_handle);
+    ::dlclose(egl_handle);
+    return Unavailable("system EGL could not create an OpenGL ES 3 context");
+  }
+
+  const EGLint pbuffer_attributes[] = {EGL_WIDTH, 8, EGL_HEIGHT, 8, EGL_NONE};
+  EGLSurface surface = create_pbuffer(display, config, pbuffer_attributes);
+  if (surface == EGL_NO_SURFACE ||
+      make_current(display, surface, surface, context) != EGL_TRUE) {
+    destroy_context(display, context);
+    terminate(display);
+    ::dlclose(gles_handle);
+    ::dlclose(egl_handle);
+    return Unavailable("system EGL could not make the OpenGL ES context current");
+  }
+
+  using GlGetStringFn = const char* (*)(std::uint32_t);
+  GlGetStringFn gl_get_string = nullptr;
+  if (get_proc_address != nullptr) {
+    gl_get_string = reinterpret_cast<GlGetStringFn>(get_proc_address("glGetString"));
+  }
+  const char* renderer_raw =
+      gl_get_string != nullptr ? gl_get_string(kGlRenderer) : nullptr;
+  const char* vendor_raw =
+      gl_get_string != nullptr ? gl_get_string(kGlVendor) : nullptr;
+  // Copy the strings: they are only valid while the context is current.
+  const std::string renderer = renderer_raw != nullptr ? renderer_raw : "";
+  const std::string vendor = vendor_raw != nullptr ? vendor_raw : "";
+
+  // The GL_VENDOR/GL_RENDERER strings are only valid while the context is
+  // current, so classify acceleration before tearing the display down.
+  const bool software = IsSoftwareRenderer(renderer.c_str(), vendor.c_str());
+
+  make_current(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  destroy_surface(display, surface);
+  destroy_context(display, context);
+  terminate(display);
+  ::dlclose(gles_handle);
+  ::dlclose(egl_handle);
+
+  if (software && !options.allow_software_device) {
+    std::string detail = "system EGL resolved to a software rasterizer";
+    if (!renderer.empty()) {
+      detail += " (renderer=";
+      detail += renderer;
+      detail += ")";
+    }
+    return {GraphicsBackendKind::kSystemEgl, CapabilityState::kLoadable,
+            HardwareAcceleration::kSoftware, std::move(detail)};
+  }
+
+  std::string detail = "validated system EGL ";
+  detail += std::to_string(major);
+  detail += ".";
+  detail += std::to_string(minor);
+  if (!vendor.empty()) {
+    detail += ", vendor=";
+    detail += vendor;
+  }
+  if (!renderer.empty()) {
+    detail += ", renderer=";
+    detail += renderer;
+  }
+  detail += software ? ", software" : ", hardware";
+
+  return {GraphicsBackendKind::kSystemEgl, CapabilityState::kReady,
+          software ? HardwareAcceleration::kSoftware : HardwareAcceleration::kHardware,
+          std::move(detail)};
+}
+
+}  // namespace graphics
+}  // namespace mocktail

--- a/src/legacy/legacy_runtime.cc
+++ b/src/legacy/legacy_runtime.cc
@@ -53,6 +53,8 @@
 #include "libc_shim/libc_shim.h"
 #include "linker/linker.h"
 #include "mocktail/graphics/bionic_egl_bridge.h"
+#include "mocktail/graphics/system_egl_bridge.h"
+#include "mocktail/graphics/system_egl_probe.h"
 #include "runtime/environment.h"
 #include "runtime/discord_rpc.h"
 #include "runtime/jnivm_platform_web_callbacks.h"
@@ -32283,23 +32285,63 @@ int mocktail::legacy::Run(const runtime::CommandLineOptions& options,
   // by SONAME: Chromium ANGLE also calls itself libEGL.so and would otherwise
   // win once the SDL backend has loaded it.
   mocktail::graphics::BionicEglBridge bionic_egl_bridge;
+  mocktail::graphics::SystemEglBridge system_egl_bridge;
+  const bool use_system_egl = IsEnabled("MOCKTAIL_DISABLE_AUTO_ANGLE_FALLBACK");
   if (has_window) {
-    if (!bionic_egl_bridge.Load()) {
-      std::cerr << "  [graphics] exact Bionic EGL adapter unavailable: "
-                << bionic_egl_bridge.error() << '\n';
-      if (IsEnabled("MOCKTAIL_REQUIRE_REAL_GRAPHICS")) {
-        std::cerr << "[FATAL] Windowed mode requires Mocktail's exact "
-                     "Bionic EGL adapter.\n";
-        return EXIT_FAILURE;
+    if (use_system_egl) {
+      // The OpenGL/system-egl backend routes the guest's libEGL.so and
+      // libGLESv2.so directly at the host system GL stack instead of ANGLE.
+      const mocktail::graphics::BackendCapability system_egl_capability =
+          mocktail::graphics::ProbeSystemEgl(
+              mocktail::graphics::SystemEglProbeOptions{});
+      if (system_egl_capability.state ==
+          mocktail::graphics::CapabilityState::kUnavailable) {
+        std::cerr << "  [graphics] system EGL probe failed: "
+                  << system_egl_capability.detail << '\n';
       }
-    } else {
-      for (const auto& [name, address] : bionic_egl_bridge.exports()) {
-        linker::RegisterSyntheticSymbol("libEGL.so", name, address);
-        linker::RegisterSymbol(name, address);
+      if (!system_egl_bridge.Load()) {
+        std::cerr << "  [graphics] system EGL bridge unavailable: "
+                  << system_egl_bridge.error() << '\n';
+        if (IsEnabled("MOCKTAIL_REQUIRE_REAL_GRAPHICS")) {
+          std::cerr << "[FATAL] OpenGL backend requested but the host system "
+                       "EGL/GLES stack could not be loaded.\n";
+          return EXIT_FAILURE;
+        }
+      } else {
+        for (const auto& [name, address] : system_egl_bridge.exports()) {
+          linker::RegisterSyntheticSymbol("libEGL.so", name, address);
+          linker::RegisterSyntheticSymbol("libGLESv2.so", name, address);
+          linker::RegisterSymbol(name, address);
+        }
+        std::cout << "  [graphics] system EGL backend loaded from "
+                  << system_egl_bridge.egl_library_path() << " + "
+                  << system_egl_bridge.gles_library_path() << " ("
+                  << system_egl_bridge.exports().size() << " exports)\n";
+        if (system_egl_capability.state ==
+            mocktail::graphics::CapabilityState::kUnavailable) {
+          std::cerr << "  [warn]  system EGL probe reported the host stack is "
+                       "unavailable; rendering may fail.\n";
+        }
       }
-      std::cout << "  [graphics] Bionic libEGL adapter loaded from "
-                << bionic_egl_bridge.library_path() << " ("
-                << bionic_egl_bridge.exports().size() << " exports)\n";
+    }
+    if (!use_system_egl || !system_egl_bridge.IsLoaded()) {
+      if (!bionic_egl_bridge.Load()) {
+        std::cerr << "  [graphics] exact Bionic EGL adapter unavailable: "
+                  << bionic_egl_bridge.error() << '\n';
+        if (IsEnabled("MOCKTAIL_REQUIRE_REAL_GRAPHICS")) {
+          std::cerr << "[FATAL] Windowed mode requires Mocktail's exact "
+                       "Bionic EGL adapter.\n";
+          return EXIT_FAILURE;
+        }
+      } else {
+        for (const auto& [name, address] : bionic_egl_bridge.exports()) {
+          linker::RegisterSyntheticSymbol("libEGL.so", name, address);
+          linker::RegisterSymbol(name, address);
+        }
+        std::cout << "  [graphics] Bionic libEGL adapter loaded from "
+                  << bionic_egl_bridge.library_path() << " ("
+                  << bionic_egl_bridge.exports().size() << " exports)\n";
+      }
     }
   }
 
@@ -32318,8 +32360,15 @@ int mocktail::legacy::Run(const runtime::CommandLineOptions& options,
   for (const char* name : stub_names) {
     void* h = nullptr;
     bool exact_adapter = false;
-    if (std::strcmp(name, "libEGL.so") == 0 &&
-        bionic_egl_bridge.IsLoaded()) {
+    if (std::strcmp(name, "libEGL.so") == 0 && system_egl_bridge.IsLoaded()) {
+      h = system_egl_bridge.handle();
+      exact_adapter = true;
+    } else if (std::strcmp(name, "libGLESv2.so") == 0 &&
+               system_egl_bridge.IsLoaded()) {
+      h = system_egl_bridge.gles_handle();
+      exact_adapter = true;
+    } else if (std::strcmp(name, "libEGL.so") == 0 &&
+               bionic_egl_bridge.IsLoaded()) {
       h = bionic_egl_bridge.handle();
       exact_adapter = true;
     } else if (std::strcmp(name, "libvulkan.so") == 0) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -13,6 +14,9 @@
 #include <string_view>
 #include <thread>
 #include <utility>
+#include <unistd.h>
+#include <limits.h>
+#include <sys/resource.h>
 #include <vector>
 
 #include "compat/elf_build_id.h"
@@ -217,6 +221,206 @@ void PromptFirstLaunchSignIn(
 
 }  // namespace
 
+namespace {
+// Reduce the periodic micro-stutter/hitching that OpenGL apps exhibit on the
+// Pin every online CPU to the "performance" governor so the kernel never
+// downclocks under load. Older CPUs (i7-2600 class) ramp clocks on demand and
+// the resulting latency spikes show up as judder in CPU-bound games. Best
+// effort: sysfs writes need root on most setups, so failures are silently
+// ignored.
+void ApplyCpuPerformanceGovernor() {
+  if (std::getenv("MOCKTAIL_DISABLE_CPU_GOVERNOR") != nullptr) {
+    return;
+  }
+  const long n = sysconf(_SC_NPROCESSORS_ONLN);
+  if (n <= 0) {
+    return;
+  }
+  for (long i = 0; i < n; ++i) {
+    const std::string path = "/sys/devices/system/cpu/cpu" +
+                             std::to_string(i) +
+                             "/cpufreq/scaling_governor";
+    FILE* f = fopen(path.c_str(), "w");
+    if (f != nullptr) {
+      fputs("performance", f);
+      fclose(f);
+    }
+  }
+}
+
+// proprietary NVIDIA Linux driver. These must be applied before the GL driver
+// is loaded (i.e. before window/EGL init), so we set them as early as
+// possible. Each is only set when not already provided by the user.
+void ApplyNvidiaPerformanceTuning() {
+  if (access("/proc/driver/nvidia/version", R_OK) != 0) {
+    return;
+  }
+  std::cerr << "[runtime] NVIDIA GPU detected; applying GL tuning\n";
+
+  auto set_if_unset = [](const char* name, const char* value) {
+    if (std::getenv(name) == nullptr) {
+      setenv(name, value, 1);
+    }
+  };
+
+  // USLEEP yield is the documented fix for the 1-2s periodic stutter on
+  // NVIDIA's OpenGL path (avoids busy-spin waits that desync vsync).
+  set_if_unset("__GL_YIELD", "USLEEP");
+  // Multi-threaded GL command submission.
+  set_if_unset("__GL_THREADED_OPTIMIZATIONS", "1");
+  // Let SDL bypass the X11 compositor for our window (fewer present hops).
+  set_if_unset("SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR", "1");
+  // Allow adaptive sync (G-Sync/FreeSync) when the display supports it.
+  // Harmless and a no-op on fixed-refresh panels like the 84Hz one here.
+  set_if_unset("__GL_VRR_ALLOWED", "1");
+
+  // Texture filtering at "High Performance" trades some sharpness for speed.
+  // This is the single largest driver-side quality-vs-throughput knob and the
+  // user explicitly asked for every performance lever.
+  if (std::getenv("MOCKTAIL_DISABLE_NVIDIA_TEXTURE_PERF") == nullptr) {
+    system("nvidia-settings -a '[gpu:0]/TextureFilteringQuality=0' "
+           ">/dev/null 2>&1");
+  }
+
+  // CPU-side tuning. On an older CPU (e.g. i7-2600) clock ramps and scheduler
+  // jitter cause hitches that no GL flag fixes. Best effort; all ignored if
+  // the user lacks privileges.
+  ApplyCpuPerformanceGovernor();
+  if (std::getenv("MOCKTAIL_DISABLE_RENICE") == nullptr) {
+    if (setpriority(PRIO_PROCESS, 0, -10) != 0) {
+      // Non-fatal; only relevant when CAP_SYS_NICE is unavailable.
+    }
+  }
+
+  // Persist compiled shaders to disk so the "stutter when something new loads"
+  // is a one-time cost. NVIDIA keys the cache per driver + binary, so running
+  // the same mocktail binary reuses it across sessions. Let the driver choose
+  // its per-version default location (~/.nv/GLCache on 390.x,
+  // ~/.cache/nvidia/GLCache on newer drivers) rather than overriding the path,
+  // which older drivers ignore anyway.
+  set_if_unset("__GL_SHADER_DISK_CACHE", "1");
+  set_if_unset("__GL_SHADER_DISK_CACHE_SIZE", "2147483648");
+  // AllowFlipping lets the driver present via page flips, which smooths the
+  // vsync present path and avoids the "alternating frame" judder pattern.
+  if (std::getenv("MOCKTAIL_DISABLE_NVIDIA_FLIP") == nullptr) {
+    system("nvidia-settings -a 'AllowFlipping=1' >/dev/null 2>&1");
+  }
+
+  // Pin the GPU clocks out of the PowerMizer "auto" ramp, which is the most
+  // common cause of periodic hitches. Best effort; ignore if nvidia-settings
+  // is missing or lacks privileges.
+  if (std::getenv("MOCKTAIL_DISABLE_NVIDIA_POWERMIZER_PIN") == nullptr) {
+    int rc = system(
+        "nvidia-settings -a '[gpu:0]/GPUPowerMizerMode=1' >/dev/null 2>&1");
+    if (rc != 0 && rc != 127) {
+      std::cerr << "[runtime] note: could not pin NVIDIA PowerMizer mode\n";
+    }
+  }
+  // Persistence mode keeps the driver initialized so context (re)creation and
+  // mode switches stop causing hitches. Needs root on most setups; best
+  // effort.
+  if (std::getenv("MOCKTAIL_DISABLE_NVIDIA_PERSISTENCE") == nullptr) {
+    system("nvidia-smi -pm 1 >/dev/null 2>&1");
+  }
+}
+
+// Apply the driver-level vsync setting once the config (MOCKTAIL_VSYNC) is in
+// the environment. Called after ExportRuntimeConfigEnvironment so graphics.vsync
+// is honoured: "off" uncaps the frame rate (tearing allowed), anything else
+// syncs to the display vblank.
+void ApplyNvidiaVsyncTuning() {
+  if (access("/proc/driver/nvidia/version", R_OK) != 0) {
+    return;
+  }
+  if (std::getenv("__GL_SYNC_TO_VBLANK") != nullptr) {
+    return;  // user override wins
+  }
+  const char* vsync = std::getenv("MOCKTAIL_VSYNC");
+  bool vsync_off = vsync != nullptr && std::strcmp(vsync, "off") == 0;
+  setenv("__GL_SYNC_TO_VBLANK", vsync_off ? "0" : "1", 1);
+  // Backstop: this EGL driver clamps EGL_MIN_SWAP_INTERVAL to 1, so
+  // eglSwapInterval(0) is rejected. The only reliable way to defeat vsync is
+  // the driver-level SyncToVBlank attribute, mirrored by __GL_SYNC_TO_VBLANK.
+  if (std::getenv("MOCKTAIL_DISABLE_NVIDIA_SYNCTOVRBLANK") == nullptr) {
+    system(vsync_off ? "nvidia-settings -a 'SyncToVBlank=0' >/dev/null 2>&1"
+                     : "nvidia-settings -a 'SyncToVBlank=1' >/dev/null 2>&1");
+  }
+  std::cerr << "[runtime] NVIDIA driver vsync "
+            << (vsync_off ? "disabled (vsync=off)\n" : "enabled\n");
+}
+
+// Re-exec the current process with NVIDIA-specific preloads so the driver
+// optimizations actually engage. Must run before EGL is loaded.
+//   - libpthread.so.0: NVIDIA's documented requirement for
+//     __GL_THREADED_OPTIMIZATIONS to take effect.
+//   - libmocktail_egl_vsync_shim.so: only when MOCKTAIL_VSYNC=off, forces
+//     Roblox's eglSwapInterval(1) requests to 0.
+// No-op if there is nothing to add or it is already preloaded (avoids an
+// exec loop).
+void ReexecWithNvidiaPreloads(char* const argv[]) {
+  if (access("/proc/driver/nvidia/version", R_OK) != 0) {
+    return;
+  }
+  const char* vsync = std::getenv("MOCKTAIL_VSYNC");
+  const bool vsync_off =
+      vsync != nullptr && std::strcmp(vsync, "off") == 0;
+
+  char self_exe[PATH_MAX];
+  const ssize_t len = readlink("/proc/self/exe", self_exe, sizeof(self_exe) - 1);
+  if (len < 0) {
+    return;
+  }
+  self_exe[len] = '\0';
+  const std::string exe(self_exe);
+  const std::string::size_type slash = exe.find_last_of('/');
+  const std::string dir =
+      (slash == std::string::npos ? std::string(".") : exe.substr(0, slash + 1));
+
+  const char* existing = std::getenv("LD_PRELOAD");
+  auto present = [existing](const char* lib) {
+    return existing != nullptr && std::strstr(existing, lib) != nullptr;
+  };
+
+  std::string additions;
+  auto append = [&](const std::string& lib) {
+    if (!additions.empty()) {
+      additions += ':';
+    }
+    additions += lib;
+  };
+
+  // Threaded optimizations historically needed libpthread preloaded to
+  // activate, but on glibc >= 2.34 (current Arch) libpthread is merged into
+  // libc and force-preloading it can break TLS. The binary already links
+  // pthread via std::thread/SDL, so it is opt-in only via
+  // MOCKTAIL_NVIDIA_PRELOAD_PTHREAD=1.
+  if (std::getenv("MOCKTAIL_NVIDIA_PRELOAD_PTHREAD") != nullptr &&
+      !present("libpthread.so.0")) {
+    append("libpthread.so.0");
+  }
+
+  if (vsync_off) {
+    const std::string shim = dir + "libmocktail_egl_vsync_shim.so";
+    if (access(shim.c_str(), R_OK) == 0 &&
+        !present("libmocktail_egl_vsync_shim.so")) {
+      append(shim);
+    }
+  }
+
+  if (additions.empty()) {
+    return;
+  }
+  std::string new_preload = additions;
+  if (existing != nullptr && existing[0] != '\0') {
+    new_preload += ':';
+    new_preload += existing;
+  }
+  setenv("LD_PRELOAD", new_preload.c_str(), 1);
+  execv(self_exe, argv);
+  std::cerr << "[runtime] note: could not re-exec with NVIDIA preloads\n";
+}
+}  // namespace
+
 int main(int argc, char* argv[]) {
   const auto process_started_at = std::chrono::system_clock::now();
   mocktail::runtime::CommandLineParseResult command_line =
@@ -244,6 +448,8 @@ int main(int argc, char* argv[]) {
     std::cerr << command_line_error << '\n';
     return EXIT_FAILURE;
   }
+
+  ApplyNvidiaPerformanceTuning();
 
   const mocktail::runtime::ProcessEnvironment environment;
   const std::string built_in_compatibility_manifest = environment.GetOr(
@@ -469,6 +675,14 @@ int main(int argc, char* argv[]) {
                       : "")
               << '\n';
   }
+  if (const int gles_version =
+          runtime_config.config.system_egl_gles_version();
+      gles_version != 0 &&
+      std::getenv("MOCKTAIL_SYSTEM_GLES_VERSION") == nullptr) {
+    const char* value =
+        gles_version == 32 ? "32" : gles_version == 31 ? "31" : "30";
+    setenv("MOCKTAIL_SYSTEM_GLES_VERSION", value, 1);
+  }
 
   // Register before starting helper processes or loading the Android payload.
   // libgamemode caches its shared
@@ -681,6 +895,8 @@ int main(int argc, char* argv[]) {
     std::cerr << command_line_error << '\n';
     return EXIT_FAILURE;
   }
+  ApplyNvidiaVsyncTuning();
+  ReexecWithNvidiaPreloads(argv);
   if (command_line.options.mode == mocktail::runtime::CommandMode::kRun &&
       !environment.HasNonEmpty("MOCKTAIL_NATIVE_SET_DEFAULT_POLICY_FILE") &&
       setenv("MOCKTAIL_NATIVE_SET_DEFAULT_POLICY_FILE", "1", 1) != 0) {

--- a/src/runtime/runtime_config.cc
+++ b/src/runtime/runtime_config.cc
@@ -176,6 +176,18 @@ RuntimeConfig RuntimeConfig::FromEnvironment(const Environment& environment) {
       "MOCKTAIL_GRAPHICS_BACKEND", config.graphics_backend_name_);
   config.graphics_backend_ =
       ParseGraphicsBackend(config.graphics_backend_name_);
+  if (const auto gles_version =
+          environment.Get("MOCKTAIL_SYSTEM_GLES_VERSION");
+      gles_version.has_value()) {
+    const std::string& v = *gles_version;
+    if (v == "30" || v == "3.0") {
+      config.system_egl_gles_version_ = 30;
+    } else if (v == "31" || v == "3.1") {
+      config.system_egl_gles_version_ = 31;
+    } else if (v == "32" || v == "3.2") {
+      config.system_egl_gles_version_ = 32;
+    }
+  }
   config.window_.width =
       ReadPositiveInt(environment, "MOCKTAIL_WIN_WIDTH", config.window_.width);
   config.window_.height = ReadPositiveInt(environment, "MOCKTAIL_WIN_HEIGHT",

--- a/src/runtime/runtime_config_bootstrap.cc
+++ b/src/runtime/runtime_config_bootstrap.cc
@@ -61,6 +61,10 @@ graphics:
   # Supported values: display, unlimited, 30, 60, 120, 144, 240. Unlimited
   # selects Roblox's unmodified 240-FPS scheduler maximum.
   frame_rate_limit: display
+  # String/integer (default: auto): pin the OpenGL ES client version for the
+  # system-egl (OpenGL) backend. Supported: auto, 3.0, 3.1, 3.2 (or 30/31/32).
+  # auto lets the driver and Roblox negotiate the highest compatible version.
+  gles_version: auto
   # String (default: auto): presentation synchronization: auto, on, or off.
   vsync: auto
 

--- a/src/runtime/runtime_config_file.cc
+++ b/src/runtime/runtime_config_file.cc
@@ -171,6 +171,7 @@ bool ValidateAndMap(const ValueMap& yaml, ValueMap* environment,
       "appearance.theme",
       "graphics.backend",
       "graphics.frame_rate_limit",
+      "graphics.gles_version",
       "graphics.vsync",
       "performance.multithreaded_rendering",
       "performance.physics_worker_mode",
@@ -321,6 +322,24 @@ bool ValidateAndMap(const ValueMap& yaml, ValueMap* environment,
       return false;
     }
     (*environment)["MOCKTAIL_FRAME_RATE_LIMIT"] = *frame_rate;
+  }
+  if (const auto gles_version = value("graphics.gles_version");
+      gles_version.has_value()) {
+    const std::string& v = *gles_version;
+    if (v == "auto" || v == "0" || v.empty()) {
+      // auto: leave MOCKTAIL_SYSTEM_GLES_VERSION unset so the driver and
+      // Roblox negotiate the highest compatible OpenGL ES version.
+    } else if (v == "3.0" || v == "30") {
+      (*environment)["MOCKTAIL_SYSTEM_GLES_VERSION"] = "30";
+    } else if (v == "3.1" || v == "31") {
+      (*environment)["MOCKTAIL_SYSTEM_GLES_VERSION"] = "31";
+    } else if (v == "3.2" || v == "32") {
+      (*environment)["MOCKTAIL_SYSTEM_GLES_VERSION"] = "32";
+    } else {
+      *error = "graphics.gles_version is not supported: " + v +
+               " (use auto, 3.0, 3.1, 3.2, or 30/31/32)";
+      return false;
+    }
   }
   if (const auto vsync = value("graphics.vsync"); vsync.has_value()) {
     if (*vsync != "auto" && *vsync != "on" && *vsync != "off") {

--- a/src/window/window.cc
+++ b/src/window/window.cc
@@ -862,6 +862,44 @@ Status ConfigureWindowStatePersistence(const std::filesystem::path& path) {
   return Status::Ok();
 }
 
+static void ApplySwapInterval() {
+  // Present pacing for the host GL window. Adaptive vsync (-1) prevents the
+  // classic "frame missed vblank -> drop to half refresh" stutter that plagues
+  // OpenGL games on Linux; fall back to hard vsync (1). Honour MOCKTAIL_VSYNC
+  // (auto/on/off) from the graphics.vsync config option.
+  const char* vsync = GetEnvNonEmpty("MOCKTAIL_VSYNC");
+  int interval = 1;
+  bool try_adaptive = true;
+  if (vsync != nullptr) {
+    if (StringEquals(vsync, "off")) {
+      interval = 0;
+      try_adaptive = false;
+    } else if (StringEquals(vsync, "on")) {
+      interval = 1;
+      try_adaptive = false;
+    }
+  }
+  if (try_adaptive) {
+    if (SDL_GL_SetSwapInterval(-1) == 0) {
+      if (WindowTraceEnabled()) {
+        fprintf(stderr, "  [window] swap interval -> adaptive vsync (-1)\n");
+      }
+      return;
+    }
+    if (WindowTraceEnabled()) {
+      fprintf(stderr,
+              "  [window] adaptive vsync unsupported (%s); using hard vsync\n",
+              SDL_GetError());
+    }
+  }
+  if (SDL_GL_SetSwapInterval(interval) != 0) {
+    fprintf(stderr, "  [window] SDL_GL_SetSwapInterval(%d) failed: %s\n",
+            interval, SDL_GetError());
+  } else if (WindowTraceEnabled()) {
+    fprintf(stderr, "  [window] swap interval -> %d\n", interval);
+  }
+}
+
 bool Init(int width, int height, const char* title) {
   if (g_state.initialised) {
     return true;
@@ -1206,6 +1244,8 @@ bool Init(int width, int height, const char* title) {
         g_state.egl_display, g_state.egl_config, g_state.egl_surface,
         g_state.egl_context);
   }
+
+  ApplySwapInterval();
 
   ResolveNativeWindowHandle();
 

--- a/tests/system_egl_probe_test.cc
+++ b/tests/system_egl_probe_test.cc
@@ -1,0 +1,68 @@
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "mocktail/graphics/graphics_backend.h"
+#include "mocktail/graphics/system_egl_bridge.h"
+#include "mocktail/graphics/system_egl_probe.h"
+
+namespace mocktail::graphics {
+namespace {
+
+TEST(SystemEglBridgeTest, LoadsHostSystemLibraries) {
+  SystemEglBridge bridge;
+  ASSERT_TRUE(bridge.Load()) << bridge.error();
+  EXPECT_FALSE(bridge.egl_library_path().empty());
+  EXPECT_FALSE(bridge.gles_library_path().empty());
+  // 21 EGL exports + 36 GLES exports.
+  EXPECT_EQ(bridge.exports().size(), 57u);
+
+  EXPECT_NE(bridge.Find("eglCreateWindowSurface"), nullptr);
+  EXPECT_NE(bridge.Find("eglSwapBuffers"), nullptr);
+  EXPECT_NE(bridge.Find("glDrawElements"), nullptr);
+  EXPECT_NE(bridge.Find("glGetString"), nullptr);
+}
+
+TEST(SystemEglProbeTest, ValidatesHostSystemEgl) {
+  SystemEglBridge bridge;
+  ASSERT_TRUE(bridge.Load()) << bridge.error();
+
+  const BackendCapability capability = ProbeSystemEgl(SystemEglProbeOptions{});
+  EXPECT_EQ(capability.backend, GraphicsBackendKind::kSystemEgl);
+  // The system stack must at least initialize; it is either ready (hardware or
+  // allowed software) or loadable (software, disallowed by default policy).
+  ASSERT_NE(capability.state, CapabilityState::kUnavailable)
+      << capability.detail;
+  EXPECT_FALSE(capability.detail.empty());
+}
+
+TEST(SystemEglProbeTest, SoftwareIsLoadableWhenDisallowed) {
+  SystemEglProbeOptions options;
+  options.allow_software_device = false;
+  const BackendCapability capability = ProbeSystemEgl(options);
+  if (capability.acceleration == HardwareAcceleration::kSoftware) {
+    EXPECT_EQ(capability.state, CapabilityState::kLoadable);
+  }
+}
+
+TEST(SystemEglProbeTest, SelectableThroughBackendPolicy) {
+  const BackendCapability system_egl = ProbeSystemEgl(SystemEglProbeOptions{});
+  if (system_egl.state == CapabilityState::kUnavailable) {
+    GTEST_SKIP() << "host system EGL unavailable: " << system_egl.detail;
+  }
+
+  const std::vector<BackendCapability> capabilities = {system_egl};
+  BackendSelectionPolicy policy;
+  policy.requested = GraphicsBackendKind::kSystemEgl;
+  policy.allow_fallback = false;
+  policy.require_hardware_acceleration = false;
+  policy.require_runtime_validation = false;
+
+  const BackendSelection selection =
+      SelectGraphicsBackend(policy, capabilities);
+  ASSERT_TRUE(selection.status.ok()) << selection.detail;
+  EXPECT_EQ(selection.backend, GraphicsBackendKind::kSystemEgl);
+}
+
+}  // namespace
+}  // namespace mocktail::graphics


### PR DESCRIPTION
…ing and uncapped vsync

Add a system-EGL (OpenGL) backend that routes the guest's libEGL/libGLESv2 directly at the host GL stack, plus NVIDIA-specific tuning to remove the periodic lag spikes and unlock the frame rate:

- system_egl_bridge / system_egl_probe: load host libEGL + libGLESv2 and expose them as synthetic linker symbols; selectable via the backend policy.
- egl_swap_interval_shim: LD_PRELOAD interposer that forces eglSwapInterval(0) when graphics.vsync=off, defeating the EGL_MIN_SWAP_INTERVAL=1 clamp.
- NVIDIA tuning in main.cc: __GL_YIELD=USLEEP, __GL_THREADED_OPTIMIZATIONS, __GL_VRR_ALLOWED, shader disk cache, GPUPowerMizer pin, AllowFlipping, config-driven __GL_SYNC_TO_VBLANK/SyncToVBlank, CPU performance governor, renice, persistence mode.
- window.cc ApplySwapInterval: adaptive vsync (-1 -> 1) honoring MOCKTAIL_VSYNC.
- runtime_config: graphics.gles_version + graphics.vsync mapped to env vars.
- launch.sh helper that preloads the vsync shim and applies driver tuning.

<!-- Briefly describe what this pull request adds, changes, or removes. Write it yourself and do not use AI-generated text. Link the issue with "Closes #123" or "Fixes #123". -->

Closes #
