### PR TITLE
fix(window): respect logical display resolution by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ add_library(mocktail_window STATIC
   src/window/roblox_fullscreen_menu_request_gate.cc
   src/window/video_driver_policy.cc
   src/window/window.cc
+  src/window/window_creation_policy.cc
   src/window/window_fullscreen_request_gate.cc
   src/window/window_game_surface_bridge.cc
   src/window/window_pointer_capture_owner.cc

--- a/config/mocktail.example.yaml
+++ b/config/mocktail.example.yaml
@@ -98,12 +98,15 @@ integrations:
     # application_id: 123456789012345678
 
 window:
-  # Integer (default: 1280): initial window width in pixels.
+  # Integer (default: 1280): initial window width in logical desktop units.
   width: 1280
-  # Integer (default: 720): initial window height in pixels.
+  # Integer (default: 720): initial window height in logical desktop units.
   height: 720
   # String (default: Roblox): window title.
   title: Roblox
+  # Boolean (default: false): render at physical display-pixel density instead
+  # of the logical desktop resolution. Enable only for sharper high-DPI output.
+  high_dpi: false
 
 network:
   # Boolean (default: false): follow the host HTTP/SOCKS5 proxy and

--- a/include/mocktail/platform/platform_runtime.h
+++ b/include/mocktail/platform/platform_runtime.h
@@ -26,7 +26,7 @@ struct WindowOptions {
   int height = 720;
   std::string title = "Roblox";
   WindowSurfaceApi surface_api = WindowSurfaceApi::kAngleEgl;
-  bool high_pixel_density = true;
+  bool high_pixel_density = false;
   bool initially_hidden = true;
 
   // Production callers should keep this true. Tests using SDL's dummy driver

--- a/include/runtime/runtime_config.h
+++ b/include/runtime/runtime_config.h
@@ -28,6 +28,10 @@ struct WindowConfig {
   int width = 1280;
   int height = 720;
   std::string title = "Roblox";
+  // GNOME desktop dimensions are logical units; keep the render surface at
+  // that size unless the user explicitly requests high-density rendering.
+  bool high_dpi = false;
+  bool high_dpi_valid = true;
 };
 
 struct InputCapabilityConfig {

--- a/src/runtime/runtime_config.cc
+++ b/src/runtime/runtime_config.cc
@@ -182,6 +182,9 @@ RuntimeConfig RuntimeConfig::FromEnvironment(const Environment& environment) {
                                           config.window_.height);
   config.window_.title =
       environment.GetOr("MOCKTAIL_WIN_TITLE", config.window_.title);
+  config.window_.high_dpi = ReadBoolean(environment, "MOCKTAIL_WIN_HIGH_DPI",
+                                        config.window_.high_dpi,
+                                        &config.window_.high_dpi_valid);
   config.theme_mode_ = environment.GetOr("MOCKTAIL_THEME", "system");
   const std::optional<std::string> configured_device =
       environment.Get("MOCKTAIL_DEVICE_PROFILE");

--- a/src/runtime/runtime_config_bootstrap.cc
+++ b/src/runtime/runtime_config_bootstrap.cc
@@ -116,12 +116,15 @@ integrations:
     # application_id: 123456789012345678
 
 window:
-  # Integer (default: 1280): initial window width in pixels.
+  # Integer (default: 1280): initial window width in logical desktop units.
   width: 1280
-  # Integer (default: 720): initial window height in pixels.
+  # Integer (default: 720): initial window height in logical desktop units.
   height: 720
   # String (default: Roblox): window title.
   title: Roblox
+  # Boolean (default: false): render at physical display-pixel density instead
+  # of the logical desktop resolution. Enable only for sharper high-DPI output.
+  high_dpi: false
 
 network:
   # Boolean (default: false): follow the host HTTP/SOCKS5 proxy and

--- a/src/runtime/runtime_config_file.cc
+++ b/src/runtime/runtime_config_file.cc
@@ -178,10 +178,11 @@ bool ValidateAndMap(const ValueMap& yaml, ValueMap* environment,
       "performance.gamemode",
       "audio.output_device",
       "audio.input_device",
-      "window.width",
-      "window.height",
-      "window.title",
-      "input.touch_enabled",
+       "window.width",
+       "window.height",
+       "window.title",
+       "window.high_dpi",
+       "input.touch_enabled",
       "compatibility.desktop_playability",
       "network.use_system_proxy",
       "network.proxy_host",
@@ -410,6 +411,14 @@ bool ValidateAndMap(const ValueMap& yaml, ValueMap* environment,
       return false;
     }
     (*environment)["MOCKTAIL_WIN_TITLE"] = *title;
+  }
+  if (const auto high_dpi = value("window.high_dpi"); high_dpi.has_value()) {
+    bool parsed = false;
+    if (!ParseBoolean(*high_dpi, &parsed)) {
+      *error = "window.high_dpi must be true or false";
+      return false;
+    }
+    (*environment)["MOCKTAIL_WIN_HIGH_DPI"] = parsed ? "1" : "0";
   }
   if (const auto touch = value("input.touch_enabled"); touch.has_value()) {
     bool parsed = false;
@@ -722,6 +731,8 @@ RuntimeConfigLoadResult LoadRuntimeConfig(
     result.error = "graphics backend is invalid";
   } else if (!result.config.theme_mode_valid()) {
     result.error = "theme mode is invalid";
+  } else if (!result.config.window().high_dpi_valid) {
+    result.error = "window high-DPI policy is invalid";
   } else if (result.config.vsync_mode() != "auto" &&
              result.config.vsync_mode() != "on" &&
              result.config.vsync_mode() != "off") {
@@ -829,6 +840,8 @@ bool ExportRuntimeConfigEnvironment(const RuntimeConfig& config,
       SetEnvironmentValue("MOCKTAIL_WIN_HEIGHT",
                           std::to_string(config.window().height), error) &&
       SetEnvironmentValue("MOCKTAIL_WIN_TITLE", config.window().title, error) &&
+      SetEnvironmentValue("MOCKTAIL_WIN_HIGH_DPI",
+                          config.window().high_dpi ? "1" : "0", error) &&
       SetEnvironmentValue(
           "MOCKTAIL_TOUCH_MODE",
           config.input_capabilities().touch_enabled ? "on" : "off", error) &&

--- a/src/window/window.cc
+++ b/src/window/window.cc
@@ -29,6 +29,7 @@
 #include "window/vulkan_surface_recovery_gate.h"
 #include "window/window_fullscreen_request_gate.h"
 #include "window/window_fullscreen_state_sync.h"
+#include "window/window_creation_policy.h"
 #include "window/window_pointer_capture_owner.h"
 #include "window/window_resize_readiness_gate.h"
 #include "window/window_state_store.h"
@@ -801,10 +802,8 @@ bool CreateSoftwareWaitingWindow(int width, int height, const char* title) {
   fprintf(stderr,
           "  [window] TEST-ONLY graphics stubs explicitly enabled; creating "
           "a non-rendering waiting window\n");
-  SDL_WindowFlags window_flags = 0;
-  if (!IsEnabledEnv("MOCKTAIL_DISABLE_HIGH_DPI")) {
-    window_flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
-  }
+  SDL_WindowFlags window_flags = ApplyHighPixelDensityWindowFlag(
+      0, IsEnabledEnv("MOCKTAIL_WIN_HIGH_DPI"));
   if (g_state.state_persistence_active && g_state.persisted_window.fullscreen) {
     window_flags |= SDL_WINDOW_FULLSCREEN;
   } else if (g_state.state_persistence_active &&
@@ -941,10 +940,9 @@ bool Init(int width, int height, const char* title) {
       fprintf(stderr, "  [window] SDL_Init failed: %s\n", SDL_GetError());
       return false;
     }
-    SDL_WindowFlags window_flags = SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE;
-    if (!IsEnabledEnv("MOCKTAIL_DISABLE_HIGH_DPI")) {
-      window_flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
-    }
+    SDL_WindowFlags window_flags = ApplyHighPixelDensityWindowFlag(
+        SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE,
+        IsEnabledEnv("MOCKTAIL_WIN_HIGH_DPI"));
     if (g_state.state_persistence_active &&
         g_state.persisted_window.fullscreen) {
       window_flags |= SDL_WINDOW_FULLSCREEN;
@@ -1085,10 +1083,9 @@ bool Init(int width, int height, const char* title) {
   SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-  SDL_WindowFlags window_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
-  if (!IsEnabledEnv("MOCKTAIL_DISABLE_HIGH_DPI")) {
-    window_flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
-  }
+  SDL_WindowFlags window_flags = ApplyHighPixelDensityWindowFlag(
+      SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
+      IsEnabledEnv("MOCKTAIL_WIN_HIGH_DPI"));
   if (g_state.state_persistence_active && g_state.persisted_window.fullscreen) {
     window_flags |= SDL_WINDOW_FULLSCREEN;
   } else if (g_state.state_persistence_active &&

--- a/src/window/window_creation_policy.cc
+++ b/src/window/window_creation_policy.cc
@@ -1,0 +1,15 @@
+#include "window/window_creation_policy.h"
+
+namespace mocktail {
+namespace window {
+
+SDL_WindowFlags ApplyHighPixelDensityWindowFlag(SDL_WindowFlags flags,
+                                                bool high_dpi) {
+  if (high_dpi) {
+    return flags | SDL_WINDOW_HIGH_PIXEL_DENSITY;
+  }
+  return flags & ~SDL_WINDOW_HIGH_PIXEL_DENSITY;
+}
+
+}  // namespace window
+}  // namespace mocktail

--- a/src/window/window_creation_policy.h
+++ b/src/window/window_creation_policy.h
@@ -1,0 +1,15 @@
+#ifndef MOCKTAIL_WINDOW_WINDOW_CREATION_POLICY_H_
+#define MOCKTAIL_WINDOW_WINDOW_CREATION_POLICY_H_
+
+#include <SDL3/SDL_video.h>
+
+namespace mocktail {
+namespace window {
+
+SDL_WindowFlags ApplyHighPixelDensityWindowFlag(SDL_WindowFlags flags,
+                                                bool high_dpi);
+
+}  // namespace window
+}  // namespace mocktail
+
+#endif  // MOCKTAIL_WINDOW_WINDOW_CREATION_POLICY_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -443,6 +443,15 @@ target_link_libraries(window_surface_lifecycle_test PRIVATE
 )
 mocktail_apply_compile_options(window_surface_lifecycle_test)
 
+add_executable(window_creation_policy_test
+  window_creation_policy_test.cc
+)
+target_link_libraries(window_creation_policy_test PRIVATE
+  mocktail_window
+  GTest::gtest_main
+)
+mocktail_apply_compile_options(window_creation_policy_test)
+
 add_executable(window_game_surface_bridge_test
   window_game_surface_bridge_test.cc
 )
@@ -878,6 +887,7 @@ gtest_discover_tests(vulkan_present_progress_gate_test)
 gtest_discover_tests(vulkan_text_overlay_compositor_test)
 gtest_discover_tests(video_driver_policy_test)
 gtest_discover_tests(window_surface_lifecycle_test)
+gtest_discover_tests(window_creation_policy_test)
 gtest_discover_tests(window_game_surface_bridge_test)
 gtest_discover_tests(window_resize_readiness_gate_test)
 gtest_discover_tests(window_fullscreen_request_gate_test)

--- a/tests/runtime_config_file_test.cc
+++ b/tests/runtime_config_file_test.cc
@@ -162,11 +162,16 @@ TEST(RuntimeConfigBootstrapTest,
            "# Boolean (default: true): never expose private or reserved "
            "joins.\n      public_servers_only: true",
            "#   playing: \"{place_name}\"\n    #   state: Playing Roblox",
-           "# Integer (default: 1280): initial window width in pixels.\n  "
-           "width: 1280",
-           "# Integer (default: 720): initial window height in pixels.\n  "
-           "height: 720",
-           "# String (default: Roblox): window title.\n  title: Roblox",
+            "# Integer (default: 1280): initial window width in logical desktop "
+            "units.\n  "
+            "width: 1280",
+            "# Integer (default: 720): initial window height in logical desktop "
+            "units.\n  "
+            "height: 720",
+            "# String (default: Roblox): window title.\n  title: Roblox",
+            "# Boolean (default: false): render at physical display-pixel density instead\n  "
+            "# of the logical desktop resolution. Enable only for sharper high-DPI output.\n  "
+            "high_dpi: false",
            "# HostAbi profile, run two isolated canaries with the selected "
            "graphics\n  "
            "# backend, and promote only on success. An existing current "
@@ -299,6 +304,7 @@ window:
   width: 1920
   height: 1080
   title: Mocktail Desktop
+  high_dpi: true
 input:
   touch_enabled: false
 network:
@@ -345,6 +351,7 @@ updates:
   EXPECT_EQ(loaded.config.window().width, 1920);
   EXPECT_EQ(loaded.config.window().height, 1080);
   EXPECT_EQ(loaded.config.window().title, "Mocktail Desktop");
+  EXPECT_TRUE(loaded.config.window().high_dpi);
   EXPECT_FALSE(loaded.config.input_capabilities().touch_enabled);
   EXPECT_TRUE(loaded.config.desktop_playability());
   ASSERT_TRUE(loaded.config.roblox_http_user_agent().has_value());
@@ -390,6 +397,8 @@ input:
   touch_enabled: true
 compatibility:
   desktop_playability: false
+window:
+  high_dpi: true
 network:
   proxy_host: yaml-proxy.example.test
   proxy_port: 8080
@@ -406,6 +415,7 @@ network:
       {"MOCKTAIL_AUDIO_INPUT_DEVICE", "Environment Microphone"},
       {"MOCKTAIL_TOUCH_MODE", "off"},
       {"MOCKTAIL_DESKTOP_PLAYABILITY", "1"},
+      {"MOCKTAIL_WIN_HIGH_DPI", "0"},
       {"MOCKTAIL_HTTP_PROXY_HOST", "env-proxy.example.test"},
       {"MOCKTAIL_HTTP_PROXY_PORT", "1080"},
   });
@@ -424,6 +434,7 @@ network:
   EXPECT_EQ(loaded.config.audio_output_device(), "Environment Headset");
   EXPECT_EQ(loaded.config.audio_input_device(), "Environment Microphone");
   EXPECT_FALSE(loaded.config.input_capabilities().touch_enabled);
+  EXPECT_FALSE(loaded.config.window().high_dpi);
   EXPECT_TRUE(loaded.config.desktop_playability());
   ASSERT_TRUE(loaded.config.roblox_http_user_agent().has_value());
   EXPECT_EQ(*loaded.config.roblox_http_user_agent(),
@@ -450,6 +461,21 @@ audio:
   std::string error;
   EXPECT_FALSE(ExportRuntimeConfigEnvironment(from_environment, &error));
   EXPECT_NE(error.find("invalid audio output device"), std::string::npos);
+}
+
+TEST(RuntimeConfigFileTest, RejectsInvalidHighDpiPolicy) {
+  TemporaryDirectory temporary;
+  const std::filesystem::path file = temporary.Write(R"yaml(
+version: 1
+window:
+  high_dpi: yes
+)yaml");
+
+  const RuntimeConfigLoadResult loaded =
+      LoadRuntimeConfig(MapEnvironment(), file);
+
+  EXPECT_FALSE(loaded);
+  EXPECT_NE(loaded.error.find("window.high_dpi"), std::string::npos);
 }
 
 TEST(RuntimeConfigFileTest, RejectsUnsafeAudioInputDevice) {
@@ -572,6 +598,22 @@ TEST(RuntimeConfigFileTest, ExportsMultithreadedRenderingPolicy) {
   ASSERT_TRUE(ExportRuntimeConfigEnvironment(disabled, &error)) << error;
   EXPECT_STREQ(getenv("MOCKTAIL_MULTITHREADED_RENDERING"), "0");
   unsetenv("MOCKTAIL_MULTITHREADED_RENDERING");
+}
+
+TEST(RuntimeConfigFileTest, ExportsHighDpiWindowPolicy) {
+  unsetenv("MOCKTAIL_WIN_HIGH_DPI");
+  std::string error;
+  const RuntimeConfig default_config =
+      RuntimeConfig::FromEnvironment(MapEnvironment());
+  ASSERT_TRUE(ExportRuntimeConfigEnvironment(default_config, &error)) << error;
+  ASSERT_NE(getenv("MOCKTAIL_WIN_HIGH_DPI"), nullptr);
+  EXPECT_STREQ(getenv("MOCKTAIL_WIN_HIGH_DPI"), "0");
+
+  const RuntimeConfig high_dpi = RuntimeConfig::FromEnvironment(
+      MapEnvironment({{"MOCKTAIL_WIN_HIGH_DPI", "1"}}));
+  ASSERT_TRUE(ExportRuntimeConfigEnvironment(high_dpi, &error)) << error;
+  EXPECT_STREQ(getenv("MOCKTAIL_WIN_HIGH_DPI"), "1");
+  unsetenv("MOCKTAIL_WIN_HIGH_DPI");
 }
 
 TEST(RuntimeConfigFileTest, ExportsPhysicsWorkerMode) {

--- a/tests/runtime_config_test.cc
+++ b/tests/runtime_config_test.cc
@@ -43,6 +43,8 @@ TEST(RuntimeConfigTest, UsesSupportedDefaults) {
   EXPECT_EQ(config.window().width, 1280);
   EXPECT_EQ(config.window().height, 720);
   EXPECT_EQ(config.window().title, "Roblox");
+  EXPECT_FALSE(config.window().high_dpi);
+  EXPECT_TRUE(config.window().high_dpi_valid);
   EXPECT_FALSE(config.input_capabilities().touch_enabled);
   EXPECT_TRUE(config.input_capabilities().mouse_enabled);
   EXPECT_TRUE(config.input_capabilities().keyboard_enabled);
@@ -94,6 +96,7 @@ TEST(RuntimeConfigTest, ReadsTypedRuntimeValues) {
       {"MOCKTAIL_WIN_WIDTH", "1920"},
       {"MOCKTAIL_WIN_HEIGHT", "1080"},
       {"MOCKTAIL_WIN_TITLE", "Mocktail Test"},
+      {"MOCKTAIL_WIN_HIGH_DPI", "true"},
       {"MOCKTAIL_TOUCH_MODE", "on"},
       {"MOCKTAIL_DESKTOP_PLAYABILITY", "0"},
       {"MOCKTAIL_FRAME_RATE_LIMIT", "144"},
@@ -122,6 +125,8 @@ TEST(RuntimeConfigTest, ReadsTypedRuntimeValues) {
   EXPECT_EQ(config.window().width, 1920);
   EXPECT_EQ(config.window().height, 1080);
   EXPECT_EQ(config.window().title, "Mocktail Test");
+  EXPECT_TRUE(config.window().high_dpi);
+  EXPECT_TRUE(config.window().high_dpi_valid);
   EXPECT_TRUE(config.input_capabilities().touch_enabled);
   EXPECT_FALSE(config.desktop_playability());
   EXPECT_FALSE(config.roblox_http_user_agent().has_value());

--- a/tests/window_creation_policy_test.cc
+++ b/tests/window_creation_policy_test.cc
@@ -1,0 +1,37 @@
+#include "window/window_creation_policy.h"
+
+#include <gtest/gtest.h>
+
+namespace mocktail {
+namespace window {
+namespace {
+
+TEST(WindowCreationPolicyTest, DisablesHighDensityForEveryWindowBackend) {
+  for (const SDL_WindowFlags base_flags : {
+           static_cast<SDL_WindowFlags>(0),
+           SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE,
+           SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
+       }) {
+    const SDL_WindowFlags flags =
+        ApplyHighPixelDensityWindowFlag(base_flags, false);
+    EXPECT_EQ(flags & SDL_WINDOW_HIGH_PIXEL_DENSITY, 0);
+    EXPECT_EQ(flags, base_flags);
+  }
+}
+
+TEST(WindowCreationPolicyTest, EnablesHighDensityForEveryWindowBackend) {
+  for (const SDL_WindowFlags base_flags : {
+           static_cast<SDL_WindowFlags>(0),
+           SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE,
+           SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
+       }) {
+    const SDL_WindowFlags flags =
+        ApplyHighPixelDensityWindowFlag(base_flags, true);
+    EXPECT_NE(flags & SDL_WINDOW_HIGH_PIXEL_DENSITY, 0);
+    EXPECT_EQ(flags & ~SDL_WINDOW_HIGH_PIXEL_DENSITY, base_flags);
+  }
+}
+
+}  // namespace
+}  // namespace window
+}  // namespace mocktail


### PR DESCRIPTION
## Summary
- Default Mocktail window surfaces to the desktop's logical resolution.
- Add `window.high_dpi` as an explicit opt-in for physical-pixel rendering.
- Keep logical-to-pixel mouse input scaling intact when high-DPI rendering is enabled.
- Consolidate SDL high-density flag construction across software, Vulkan, and OpenGL paths.

## Configuration
High-DPI rendering is now opt-in:

```yaml
window:
  high_dpi: true
```

## Screenshots

### Before:
125% scale:
<img width="3072" height="1782" alt="before" src="https://github.com/user-attachments/assets/e926c3c0-5190-4021-af14-9fac9af00907" />

### After: 
125% scale:
<img width="3072" height="1782" alt="88_scale125" src="https://github.com/user-attachments/assets/c68f5e84-0316-4feb-97aa-2c63f47fe3bc" />

100% scale:
<img width="1920" height="1162" alt="88_scale100" src="https://github.com/user-attachments/assets/f70ff46e-60f7-4997-a104-49d0553fbe78" />


## Tests
[x] make test
- 998 passed, 0 failed
- 5 environment-dependent tests skipped


since #46 PR was merged issue #88 is 1/2 solved.
 
Closes #88