### PR TITLE
perf: stop presenting unthrottled frames and cut per-call overhead

### DIFF
--- a/include/jnivm/jnivm.h
+++ b/include/jnivm/jnivm.h
@@ -508,6 +508,12 @@ private:
   void InitJNIFunctionTables();
 };
 
+// The JNI trace toggles are sampled from the environment once and then cached,
+// because they are read on every JNI dispatch. Code that flips one of the
+// MOCKTAIL_*_TRACE variables after startup must call this so the next dispatch
+// re-samples them.
+void RefreshJniTraceFlags();
+
 } // namespace jnivm
 
 #endif  // MOCKTAIL_JNIVM_JNIVM_H_

--- a/src/graphics/present_mode_policy.cc
+++ b/src/graphics/present_mode_policy.cc
@@ -13,13 +13,16 @@ PresentModePolicy ResolvePresentModePolicy(std::string_view vsync_value,
   if (vsync_value == "off" || vsync_value == "0") {
     return PresentModePolicy::kUnthrottled;
   }
-  if (frame_rate_value.empty() || frame_rate_value == "display") {
-    return PresentModePolicy::kVsync;
-  }
+  // VSync `auto` means Mocktail chooses. Only an explicit `unlimited` frame
+  // rate asks for an unthrottled presentation; every other request -- including
+  // a fixed cap such as 60 or 120 -- is a request to render *less*, so the
+  // swapchain stays on FIFO. Leaving the host list unfiltered here let Roblox
+  // pick MAILBOX/IMMEDIATE and render frames the display never shows, which
+  // burns GPU and CPU for no visible benefit.
   if (frame_rate_value == "unlimited") {
     return PresentModePolicy::kUnthrottled;
   }
-  return PresentModePolicy::kHostDefault;
+  return PresentModePolicy::kVsync;
 }
 
 std::vector<VkPresentModeKHR>

--- a/src/jnivm/jnivm.cc
+++ b/src/jnivm/jnivm.cc
@@ -1,6 +1,7 @@
 #include "jnivm/jnivm.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cerrno>
 #include <cstdarg>
@@ -295,19 +296,40 @@ std::shared_ptr<Class> FallbackClassForName(const std::string& class_name) {
   return cls;
 }
 
-bool TraceEnabled() {
-  return std::getenv("MOCKTAIL_JNI_TRACE") != nullptr;
-}
-
 bool EnvironmentTraceEnabled(const char* name) {
   const char* value = std::getenv(name);
   return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
 }
 
+// These toggles sit on the per-call JNI dispatch path, where std::getenv costs
+// hundreds of nanoseconds because it rescans the whole environment. The value
+// is sampled on first use -- which happens long after startup has finished
+// writing the environment -- and cached until a runtime toggle overrides it.
+constexpr int kTraceStateUnknown = -1;
+std::atomic<int> g_jni_trace_state{kTraceStateUnknown};
+std::atomic<int> g_jni_string_trace_state{kTraceStateUnknown};
+
+bool CachedTraceState(std::atomic<int>* state, bool (*sample)()) {
+  int cached = state->load(std::memory_order_relaxed);
+  if (cached == kTraceStateUnknown) {
+    cached = sample() ? 1 : 0;
+    state->store(cached, std::memory_order_relaxed);
+  }
+  return cached != 0;
+}
+
+bool TraceEnabled() {
+  return CachedTraceState(&g_jni_trace_state, [] {
+    return std::getenv("MOCKTAIL_JNI_TRACE") != nullptr;
+  });
+}
+
 bool StringTraceEnabled() {
-  return EnvironmentTraceEnabled("MOCKTAIL_JNI_STRING_TRACE") ||
-         EnvironmentTraceEnabled("MOCKTAIL_TRACE_ALL") ||
-         EnvironmentTraceEnabled("MOCKTAIL_FULL_TRACE");
+  return CachedTraceState(&g_jni_string_trace_state, [] {
+    return EnvironmentTraceEnabled("MOCKTAIL_JNI_STRING_TRACE") ||
+           EnvironmentTraceEnabled("MOCKTAIL_TRACE_ALL") ||
+           EnvironmentTraceEnabled("MOCKTAIL_FULL_TRACE");
+  });
 }
 
 void Trace(const char* name) {
@@ -1711,8 +1733,8 @@ void HandleVoidMethod(jobject obj, jmethodID method_id, va_list args) {
     RecordDataModelNotification(obj, type, data);
     return;
   }
-  if (ObjectClassName(obj) == "com/roblox/engine/jni/EngineJavaCallback2" &&
-      std::strlen(name) == 1 && name[0] >= 'b' && name[0] <= 'o') {
+  if (std::strlen(name) == 1 && name[0] >= 'b' && name[0] <= 'o' &&
+      ObjectClassName(obj) == "com/roblox/engine/jni/EngineJavaCallback2") {
     return;
   }
   if (std::strcmp(name, "setBaseUrl") == 0) {
@@ -4015,8 +4037,8 @@ void HandleVoidMethodA(jobject obj, jmethodID method_id, const jvalue *args) {
                                 static_cast<jstring>(args[1].l));
     return;
   }
-  if (ObjectClassName(obj) == "com/roblox/engine/jni/EngineJavaCallback2" &&
-      std::strlen(name) == 1 && name[0] >= 'a' && name[0] <= 'o') {
+  if (std::strlen(name) == 1 && name[0] >= 'a' && name[0] <= 'o' &&
+      ObjectClassName(obj) == "com/roblox/engine/jni/EngineJavaCallback2") {
     return;
   }
   if (std::strcmp(name, "setBaseUrl") == 0) {
@@ -4242,16 +4264,16 @@ jboolean JNICALL CallBooleanMethod(JNIEnv* /*env*/, jobject obj,
     handled =
         PackageManagerBooleanResultForMethodV(obj, methodID, args, &result);
   }
+  const char* const method_name = handled ? nullptr : MethodName(methodID);
   if (!handled) {
-    handled =
-        LocalStorageBooleanResultForMethodV(MethodName(methodID), args, &result);
+    handled = LocalStorageBooleanResultForMethodV(method_name, args, &result);
   }
   if (!handled) {
-    handled = CookieBooleanResultForMethod(MethodName(methodID), &result);
+    handled = CookieBooleanResultForMethod(method_name, &result);
   }
   va_end(args);
   return handled ? result
-                 : BooleanResultForReceiverMethod(obj, MethodName(methodID));
+                 : BooleanResultForReceiverMethod(obj, method_name);
 }
 
 jint JNICALL CallIntMethod(JNIEnv* /*env*/, jobject obj, jmethodID methodID, ...) {
@@ -4277,10 +4299,11 @@ jlong JNICALL CallLongMethod(JNIEnv* /*env*/, jobject obj,
     std::cout << "  [JNI] CallLongMethod: " << MethodName(methodID) << '\n';
   }
   jlong result = 0;
-  if (LocalStorageLongResultForMethod(MethodName(methodID), &result)) {
+  const char* const method_name = MethodName(methodID);
+  if (LocalStorageLongResultForMethod(method_name, &result)) {
     return result;
   }
-  return LongResultForReceiverMethod(obj, MethodName(methodID));
+  return LongResultForReceiverMethod(obj, method_name);
 }
 
 jobject ConstructObjectV(jclass clazz, jmethodID methodID, va_list args) {
@@ -4289,28 +4312,29 @@ jobject ConstructObjectV(jclass clazz, jmethodID methodID, va_list args) {
   if (object_class == nullptr) {
     return object;
   }
+  // Resolved once: every branch below asks for the same name and signature, and
+  // each lookup takes the global JNI state lock.
+  const bool long_handle_constructor =
+      std::strcmp(MethodName(methodID), "<init>") == 0 &&
+      std::strcmp(MethodSignature(methodID), "(J)V") == 0;
   if (object_class->GetName() ==
           "com/roblox/universalapp/messagebus/Connection" &&
-      std::strcmp(MethodName(methodID), "<init>") == 0 &&
-      std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+      long_handle_constructor) {
     const jlong handle = va_arg(args, jlong);
     SetLongFieldRaw(object, "a", handle);
     SetLongFieldRaw(object, "f10205a", handle);
     SetLongFieldRaw(object, "nativePtr", handle);
   } else if (object_class->GetName() ==
                  "com/roblox/engine/jni/memstorage/Connection" &&
-             std::strcmp(MethodName(methodID), "<init>") == 0 &&
-             std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+             long_handle_constructor) {
     SetLongFieldRaw(object, "ref", va_arg(args, jlong));
   } else if (object_class->GetName() ==
                  "org/webrtc/voiceengine/WebRtcAudioRecord" &&
-             std::strcmp(MethodName(methodID), "<init>") == 0 &&
-             std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+             long_handle_constructor) {
     SetLongFieldRaw(object, "nativeAudioRecord", va_arg(args, jlong));
   } else if (object_class->GetName() ==
                  "org/webrtc/voiceengine/WebRtcAudioTrack" &&
-             std::strcmp(MethodName(methodID), "<init>") == 0 &&
-             std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+             long_handle_constructor) {
     SetLongFieldRaw(object, "nativeAudioTrack", va_arg(args, jlong));
   } else if (object_class->GetName() ==
                  "com/roblox/engine/jni/model/NativeTextBoxInfo" &&
@@ -4372,27 +4396,28 @@ jobject ConstructObjectA(jclass clazz, jmethodID methodID, const jvalue *args) {
   if (object_class == nullptr || args == nullptr) {
     return object;
   }
+  // Resolved once: every branch below asks for the same name and signature, and
+  // each lookup takes the global JNI state lock.
+  const bool long_handle_constructor =
+      std::strcmp(MethodName(methodID), "<init>") == 0 &&
+      std::strcmp(MethodSignature(methodID), "(J)V") == 0;
   if (object_class->GetName() ==
           "com/roblox/universalapp/messagebus/Connection" &&
-      std::strcmp(MethodName(methodID), "<init>") == 0 &&
-      std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+      long_handle_constructor) {
     SetLongFieldRaw(object, "a", args[0].j);
     SetLongFieldRaw(object, "f10205a", args[0].j);
     SetLongFieldRaw(object, "nativePtr", args[0].j);
   } else if (object_class->GetName() ==
                  "com/roblox/engine/jni/memstorage/Connection" &&
-             std::strcmp(MethodName(methodID), "<init>") == 0 &&
-             std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+             long_handle_constructor) {
     SetLongFieldRaw(object, "ref", args[0].j);
   } else if (object_class->GetName() ==
                  "org/webrtc/voiceengine/WebRtcAudioRecord" &&
-             std::strcmp(MethodName(methodID), "<init>") == 0 &&
-             std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+             long_handle_constructor) {
     SetLongFieldRaw(object, "nativeAudioRecord", args[0].j);
   } else if (object_class->GetName() ==
                  "org/webrtc/voiceengine/WebRtcAudioTrack" &&
-             std::strcmp(MethodName(methodID), "<init>") == 0 &&
-             std::strcmp(MethodSignature(methodID), "(J)V") == 0) {
+             long_handle_constructor) {
     SetLongFieldRaw(object, "nativeAudioTrack", args[0].j);
   } else if (object_class->GetName() ==
                  "com/roblox/engine/jni/model/NativeTextBoxInfo" &&
@@ -7014,6 +7039,11 @@ void VM::InitJNIFunctionTables() {
 
   jni_env_ = &jni_env_storage_;
   jni_env_->functions = &native_interface_;
+}
+
+void RefreshJniTraceFlags() {
+  g_jni_trace_state.store(kTraceStateUnknown, std::memory_order_relaxed);
+  g_jni_string_trace_state.store(kTraceStateUnknown, std::memory_order_relaxed);
 }
 
 }  // namespace jnivm

--- a/src/legacy/legacy_runtime.cc
+++ b/src/legacy/legacy_runtime.cc
@@ -2616,7 +2616,7 @@ bool IsEnabled(const char* name) {
     return false;
   }
   const char* value = std::getenv(name);
-  return value != nullptr && value[0] != '\0' && std::string(value) != "0";
+  return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
 }
 
 bool IsDisabled(const char* name) {
@@ -2749,6 +2749,7 @@ void EnableFullTraceIfRequested() {
   for (const char* name : kTraceEnvNames) {
     setenv(name, "1", 1);
   }
+  jnivm::RefreshJniTraceFlags();
 }
 
 void SetEnvDefault(const char* name, const char* value) {
@@ -30085,6 +30086,7 @@ void* DelayedStartLuaAppThread(void* arg) {
 
   if (IsEnabled("MOCKTAIL_TRACE_START_LUA_JNI")) {
     setenv("MOCKTAIL_JNI_TRACE", "1", 1);
+    jnivm::RefreshJniTraceFlags();
   }
 
   std::cout << "  [engine] delayed nativeAppBridgeStartLuaAppDM\n"
@@ -30866,6 +30868,7 @@ void* EngineStartupThread(void* arg) {
               << std::flush;
     if (IsEnabled("MOCKTAIL_TRACE_POST_CLIENT_SETTINGS_JNI")) {
       setenv("MOCKTAIL_JNI_TRACE", "1", 1);
+      jnivm::RefreshJniTraceFlags();
     }
     if (sigsetjmp(g_post_client_settings_jmp_buf, 1) == 0) {
       g_post_client_settings_recovery_in_progress = 1;
@@ -30958,6 +30961,7 @@ void* EngineStartupThread(void* arg) {
     env = ensure_env();
     if (IsEnabled("MOCKTAIL_TRACE_APP_BRIDGE_APP_START_JNI")) {
       setenv("MOCKTAIL_JNI_TRACE", "1", 1);
+      jnivm::RefreshJniTraceFlags();
     }
     if (context->native_set_is_first_install) {
       std::cout << "  [engine] NativeAppBridgeInterface.setIsFirstInstall\n"
@@ -31366,6 +31370,7 @@ void* EngineStartupThread(void* arg) {
       env = ensure_env();
       if (IsEnabled("MOCKTAIL_TRACE_START_LUA_JNI")) {
         setenv("MOCKTAIL_JNI_TRACE", "1", 1);
+        jnivm::RefreshJniTraceFlags();
       }
       std::cout << "  [engine] nativeAppBridgeStartLuaAppDM\n"
                 << std::flush;
@@ -31675,6 +31680,7 @@ void* EngineStartupThread(void* arg) {
     env = ensure_env();
     if (IsEnabled("MOCKTAIL_TRACE_START_LUA_JNI")) {
       setenv("MOCKTAIL_JNI_TRACE", "1", 1);
+      jnivm::RefreshJniTraceFlags();
     }
     std::cout << "  [engine] post-StartApp nativeAppBridgeStartLuaAppDM\n"
               << std::flush;
@@ -34362,6 +34368,9 @@ int mocktail::legacy::Run(const runtime::CommandLineOptions& options,
       return true;
     };
     int main_loop_ticks = 0;
+    // Sampled once: std::getenv rescans the whole environment and this runs on
+    // every pump iteration.
+    const bool trace_main_loop = IsEnabled("MOCKTAIL_TRACE_MAIN_LOOP");
     while (true) {
       const bool keep_window_open = mocktail::window::PumpEvents();
       game_surface_events_completed = drain_game_surface_events();
@@ -34369,7 +34378,7 @@ int mocktail::legacy::Run(const runtime::CommandLineOptions& options,
         break;
       }
       ++main_loop_ticks;
-      if (IsEnabled("MOCKTAIL_TRACE_MAIN_LOOP") &&
+      if (trace_main_loop &&
           (main_loop_ticks <= 10 || main_loop_ticks % 100 == 0)) {
         std::cerr << "  [main] SDL event loop tick #" << main_loop_ticks
                   << '\n'
@@ -34388,6 +34397,7 @@ int mocktail::legacy::Run(const runtime::CommandLineOptions& options,
         }
         if (IsEnabled("MOCKTAIL_TRACE_START_LUA_JNI")) {
           setenv("MOCKTAIL_JNI_TRACE", "1", 1);
+          jnivm::RefreshJniTraceFlags();
         }
         std::cout << "  [main] delayed nativeAppBridgeStartLuaAppDM\n"
                   << std::flush;

--- a/src/window/window.cc
+++ b/src/window/window.cc
@@ -2100,7 +2100,9 @@ bool PumpEvents() {
   MaybePersistWindowState();
   MaybeRecoverVulkanSurface();
   MaybeReportVulkanPresentStall();
-  const char* auto_exit_value =
+  // Sampled once: PumpEvents runs at the input-pump rate and std::getenv
+  // rescans the whole environment on every call.
+  static const char* const auto_exit_value =
       GetEnvNonEmpty("MOCKTAIL_AUTO_EXIT_AFTER_PRESENT_MS");
   if (!g_state.quit_requested && auto_exit_value != nullptr) {
     char* end = nullptr;
@@ -2128,7 +2130,12 @@ void PaceInputPump() {
   const uint64_t delay_ns =
       g_input_pump_pacer.DelayBeforeNextPump(SDL_GetTicksNS());
   if (delay_ns != 0) {
-    SDL_DelayPrecise(delay_ns);
+    // SDL_DelayPrecise busy-spins the tail of the interval to land on an exact
+    // deadline. At the input-pump rate that burns a measurable slice of a core
+    // for the whole session. The pacer already rebases a missed deadline
+    // instead of issuing catch-up pumps, so only the average rate matters here
+    // and an ordinary sleep is enough.
+    SDL_DelayNS(delay_ns);
   }
 }
 

--- a/tests/present_mode_policy_test.cc
+++ b/tests/present_mode_policy_test.cc
@@ -13,6 +13,22 @@ TEST(PresentModePolicyTest, DerivesDisplayAndUnlimitedDefaults) {
             PresentModePolicy::kUnthrottled);
 }
 
+TEST(PresentModePolicyTest, FixedFrameRateStaysThrottledUnderAutoVsync) {
+  // A fixed cap is a request to render less, so `auto` must not hand Roblox an
+  // unfiltered mode list it would answer with MAILBOX or IMMEDIATE.
+  EXPECT_EQ(ResolvePresentModePolicy("auto", "60"), PresentModePolicy::kVsync);
+  EXPECT_EQ(ResolvePresentModePolicy("auto", "120"), PresentModePolicy::kVsync);
+  EXPECT_EQ(ResolvePresentModePolicy("auto", "240"), PresentModePolicy::kVsync);
+  EXPECT_EQ(ResolvePresentModePolicy("", "120"), PresentModePolicy::kVsync);
+}
+
+TEST(PresentModePolicyTest, ExplicitVsyncRequestsStillWin) {
+  EXPECT_EQ(ResolvePresentModePolicy("off", "120"),
+            PresentModePolicy::kUnthrottled);
+  EXPECT_EQ(ResolvePresentModePolicy("on", "unlimited"),
+            PresentModePolicy::kVsync);
+}
+
 TEST(PresentModePolicyTest, FiltersWithoutFabricatingHostModes) {
   const std::vector<VkPresentModeKHR> host = {VK_PRESENT_MODE_IMMEDIATE_KHR,
                                               VK_PRESENT_MODE_FIFO_KHR};


### PR DESCRIPTION
Four independent sources of avoidable CPU/GPU load.

## Presentation (the GPU one)

`vsync: auto` combined with a fixed `frame_rate_limit` resolved to `kHostDefault`, which handed Roblox the unfiltered host present-mode list. Roblox answers that with MAILBOX or IMMEDIATE, so the engine rendered as fast as the GPU allowed and threw away every frame the display never scanned out. No test covered this combination.

Only an explicit `unlimited` frame rate now selects an unthrottled mode. A numeric cap is a request to render *less*, so the swapchain stays on FIFO. `display` and explicit `vsync: on`/`off` are unchanged.

## Input pump pacing

`SDL_DelayPrecise` busy-spins the tail of every interval to land on an exact deadline. The pacer already rebases a missed deadline instead of issuing catch-up pumps, so only the average rate matters and an ordinary sleep is enough.

| pacing at 240 Hz, 3 s | CPU | median interval (target 4.167 ms) | |---|---|---|
| `SDL_DelayPrecise` | 2.2% of a core | 4.167 ms | | `SDL_DelayNS` | 0.3% of a core | 4.166 ms |

## Environment lookups on per-call paths

`std::getenv` rescans the whole environment: 250 ns per call on the test machine against 3.7 ns cached. The JNI trace toggles were read on *every JNI dispatch*. They are now sampled on first use and cached, with `RefreshJniTraceFlags()` wired into all seven sites that flip the variables at runtime so `MOCKTAIL_TRACE_START_LUA_JNI` and friends keep working. Same treatment for the per-tick main-loop toggle and the per-pump auto-exit knob. `IsEnabled()` no longer heap-allocates a `std::string` per call.

## JNI dispatch

`CallBooleanMethod`, `CallLongMethod`, `ConstructObjectV` and `ConstructObjectA` resolved the same method id two to four times per call, each taking the global recursive JNI state lock. The two void-method dispatchers also evaluated a locked, allocating `ObjectClassName()` before the cheap single-character name test that gates it; both operands are pure, so ordering the cheap test first is equivalent.

## Testing

Clean build, no warnings. 955/957 tests pass. The two failures (`CompatibilityGateTest.UnknownBuildFailsBeforeNativeLoad`, `ThinDependencyBootstrapTest.PackageManagersAndLaunch`) reproduce identically on unmodified `main` — missing `python-capstone` and no Roblox payload on the test machine — so they are pre-existing and environmental, not regressions.

Not measured: the end-to-end effect in a running game. That needs a Roblox payload and an interactive GPU session. The numbers above are microbenchmarks plus static analysis of the hot paths.

Behaviour is unchanged except for the present mode under `vsync: auto` with a fixed cap, which is now covered by tests.

<!-- Briefly describe what this pull request adds, changes, or removes. Write it yourself and do not use AI-generated text. Link the issue with "Closes #123" or "Fixes #123". -->

Closes #
