### PR TITLE
fix(vulkan): avoid fullscreen crash on suboptimal acquire

### DIFF
--- a/include/mocktail/graphics/android_vulkan_wsi_adapter.h
+++ b/include/mocktail/graphics/android_vulkan_wsi_adapter.h
@@ -23,8 +23,8 @@ inline constexpr AndroidVulkanResult kAndroidVulkanErrorInitializationFailed =
 inline constexpr char kAndroidSurfaceExtension[] =
     "VK_KHR_android_surface";
 
-// Roblox treats VK_SUBOPTIMAL_KHR as a hard error. Map it to OUT_OF_DATE so
-// the guest recreates the swapchain instead of presenting an obsolete surface.
+// VK_SUBOPTIMAL_KHR still returns a usable image. Roblox handles it as a fatal
+// error, so accept it until the host reports a real out-of-date surface.
 VkResult NormalizeAndroidSwapchainResult(VkResult result);
 
 // Returned storage owns the translated extension names.

--- a/src/graphics/android_vulkan_wsi_adapter.cc
+++ b/src/graphics/android_vulkan_wsi_adapter.cc
@@ -27,7 +27,7 @@ Status AppendUniqueExtension(const std::string& extension,
 }  // namespace
 
 VkResult NormalizeAndroidSwapchainResult(VkResult result) {
-  return result == VK_SUBOPTIMAL_KHR ? VK_ERROR_OUT_OF_DATE_KHR : result;
+  return result == VK_SUBOPTIMAL_KHR ? VK_SUCCESS : result;
 }
 
 Status TranslateAndroidVulkanInstanceExtensions(

--- a/src/graphics/bionic_vulkan_loader_adapter.cc
+++ b/src/graphics/bionic_vulkan_loader_adapter.cc
@@ -286,8 +286,8 @@ void NoteSuboptimalTranslation() {
   static std::atomic<bool> logged{false};
   if (!logged.exchange(true, std::memory_order_relaxed)) {
     std::fprintf(stderr,
-                 "  [vulkan] mapped VK_SUBOPTIMAL_KHR to OUT_OF_DATE so the "
-                 "swapchain can rebuild\n");
+                 "  [vulkan] accepted VK_SUBOPTIMAL_KHR; the acquired image "
+                 "remains usable\n");
   }
 }
 
@@ -1569,8 +1569,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(
   if (fps_trace) {
     AcquireWaitTrace().Record(acquire_start_ns);
   }
-  const VkResult result =
-      mocktail::graphics::NormalizeAndroidSwapchainResult(host_result);
+  const VkResult result = NormalizeSwapchainResult(host_result);
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
     const NoteSurfaceOutOfDateFn note_surface_out_of_date =
         State().note_surface_out_of_date.load(std::memory_order_acquire);
@@ -1594,8 +1593,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImage2KHR(
   }
   const VkResult host_result =
       host_acquire(device, acquire_info, image_index);
-  const VkResult result =
-      mocktail::graphics::NormalizeAndroidSwapchainResult(host_result);
+  const VkResult result = NormalizeSwapchainResult(host_result);
   if (result == VK_ERROR_OUT_OF_DATE_KHR) {
     const NoteSurfaceOutOfDateFn note_surface_out_of_date =
         State().note_surface_out_of_date.load(std::memory_order_acquire);

--- a/tests/platform_graphics_foundation_test.cc
+++ b/tests/platform_graphics_foundation_test.cc
@@ -274,12 +274,12 @@ TEST(AndroidVulkanWsiAdapterTest, LeavesNonSurfaceExtensionsUnchanged) {
             (std::vector<std::string>{"VK_EXT_debug_utils"}));
 }
 
-TEST(AndroidVulkanWsiAdapterTest, MapsSuboptimalToOutOfDateForSwapchainRebuild) {
-  constexpr VkResult kOutOfDate = static_cast<VkResult>(-1000001004);
+TEST(AndroidVulkanWsiAdapterTest, AcceptsSuboptimalSwapchainImages) {
   EXPECT_EQ(graphics::NormalizeAndroidSwapchainResult(VK_SUBOPTIMAL_KHR),
-            kOutOfDate);
+            VK_SUCCESS);
   EXPECT_EQ(graphics::NormalizeAndroidSwapchainResult(VK_SUCCESS),
             VK_SUCCESS);
+  constexpr VkResult kOutOfDate = static_cast<VkResult>(-1000001004);
   EXPECT_EQ(graphics::NormalizeAndroidSwapchainResult(kOutOfDate), kOutOfDate);
 }
 


### PR DESCRIPTION
## Summary

Fixes the fullscreen crush and Alt-Tab crash caused by Vulkan swapchain status handling.

`VK_SUBOPTIMAL_KHR` indicates that Vulkan returned a usable acquired image, but the swapchain no longer perfectly matches the window surface. Mocktail previously converted this advisory result into `VK_ERROR_OUT_OF_DATE_KHR`.

Roblox treats `VK_ERROR_OUT_OF_DATE_KHR` from `vkAcquireNextImageKHR` as fatal and crashes. This change reports suboptimal acquired images as `VK_SUCCESS`, while preserving handling for genuine `VK_ERROR_OUT_OF_DATE_KHR` results.

## Testing

- Built `mocktail`
- Ran `platform_graphics_foundation_test`
- Ran a real direct-Vulkan fullscreen transition with `MOCKTAIL_FULLSCREEN_READINESS=1`
- Confirmed `VK_SUBOPTIMAL_KHR` is accepted and Mocktail exits cleanly without a crash


Closes #103 